### PR TITLE
Add container.docker module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import container
 setup(
     name='ansible-container',
     version=container.__version__,
-    packages=['container', 'container.shipit', 'container.shipit.openshift', 'container.shipit.openshift.modules'],
+    packages=['container', 'container.docker', 'container.shipit', 'container.shipit.openshift', 'container.shipit.openshift.modules'],
     include_package_data=True,
     url='https://github.com/j00bar/ansible-container',
     license='LGPLv3 (See LICENSE file for terms)',


### PR DESCRIPTION
ran into following error:
-----
ansible-container build
No module named docker.engine
-----

Found that the module was missing in the setup.py