### PR TITLE
fix "No module named container.cli" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 setup(
     name='ansible-container',
     version=container.__version__,
-    packages=find_packages(include='container'),
+    packages=find_packages(),
     include_package_data=True,
     url='https://github.com/ansible/ansible-container',
     license='LGPLv3 (See LICENSE file for terms)',


### PR DESCRIPTION
Ran into issue #41 earlier, figured out what was going on and fixed it.  Not sure what the downstream impacts are given I'm not a python expert, will rely on reviews for guidance there.

Looks like there's no argument 'include' per the [find_packages doc](http://code.nabla.net/doc/setuptools/api/setuptools/setuptools.find_packages.html#setuptools.find_packages), so I removed it.

