### PR TITLE
Install docker in the ansible build container

### DIFF
--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -14,6 +14,6 @@ RUN apt-get update -y && \
 ADD hosts  /etc/ansible/inventory/hosts
 ADD ansible /ansible-tmp/
 # RUN pip install -q --no-cache-dir 'ansible=={{ ansible_version }}'
-RUN pip install -q --no-cache-dir -e git+git://github.com/ansible/ansible.git@devel#egg=ansible
+RUN pip install -q --no-cache-dir -e git+https://github.com/ansible/ansible.git@devel#egg=ansible
 RUN test '(! -f /ansible-tmp/requirements.txt)' || pip install --no-cache-dir -r /ansible-tmp/requirements.txt
 RUN rm -rf /ansible-tmp/

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -1,8 +1,16 @@
 FROM python:2.7
 
-RUN apt-get -y update && \
-    apt-get install -y python-setuptools git python-pip && \
+# Add the dockerproject repo
+RUN apt-get update -y
+RUN apt-get install -y apt-transport-https ca-certificates
+RUN echo "deb https://apt.dockerproject.org/repo debian-jessie main">/etc/apt/sources.list.d/docker.list
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+# Install required packages, including docker-engine which gives us access a docker client
+RUN apt-get update -y && \
+    apt-get install -y python-setuptools git python-pip docker-engine && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 ADD hosts  /etc/ansible/inventory/hosts
 ADD ansible /ansible-tmp/
 # RUN pip install -q --no-cache-dir 'ansible=={{ ansible_version }}'

--- a/container/templates/build-docker-compose-v1.j2.yml
+++ b/container/templates/build-docker-compose-v1.j2.yml
@@ -7,7 +7,6 @@ ansible-container:
     - DOCKER_CERT_PATH=/docker-certs/
     - COMPOSE_HTTP_TIMEOUT=3000
   volumes:
-    - {{ which_docker }}:/usr/bin/docker
     - $DOCKER_CERT_PATH:/docker-certs/
     - {{ base_path }}:/ansible-container/
   working_dir: /ansible-container/ansible/

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -12,7 +12,6 @@ services:
       {% for host in hosts %}- {{ host }}
       {% endfor %}
     volumes:
-      - {{ which_docker }}:/usr/bin/docker
       - $DOCKER_CERT_PATH:/docker-certs/
       - {{ base_path }}:/ansible-container/
     working_dir: /ansible-container/ansible/

--- a/container/templates/listhosts-docker-compose-v1.j2.yml
+++ b/container/templates/listhosts-docker-compose-v1.j2.yml
@@ -7,7 +7,6 @@ ansible-container:
     - DOCKER_CERT_PATH=/docker-certs/
     - COMPOSE_HTTP_TIMEOUT=3000
   volumes:
-    - {{ which_docker }}:/usr/bin/docker
     - $DOCKER_CERT_PATH:/docker-certs/
     - {{ base_path }}:/ansible-container/
   working_dir: /ansible-container/ansible/

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -12,7 +12,6 @@ services:
       {% for host in hosts %}- {{ host }}
       {% endfor %}
     volumes:
-      - {{ which_docker }}:/usr/bin/docker
       - $DOCKER_CERT_PATH:/docker-certs/
       - {{ base_path }}:/ansible-container/
     working_dir: /ansible-container/ansible/


### PR DESCRIPTION
This removes the volume bind of the host's docker executable to the build container. We hit multiple examples where the host's docker daemon is using a storage driver not compatible with the Python 2.7 (Debian jessie) base image container. Installing docker make the image build a little bit slower, but it's the only way to insure docker works correctly. 