### PR TITLE
Add missing https url-scheme to the upstream git repo-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prerequisites:
 
 Clone the repo:
 
-    $ git clone git@github.com:ansible/ansible-container.git
+    $ git clone https://github.com/dictvm/ansible-container.git
 
 Install ansible-container:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prerequisites:
 
 Clone the repo:
 
-    $ git clone https://github.com/dictvm/ansible-container.git
+    $ git clone https://github.com/ansible/ansible-container.git
 
 Install ansible-container:
 


### PR DESCRIPTION
Trying to clone the repo without an url scheme leads to an error, because git defaults to ssh: 

```
git clone git@github.com:ansible/ansible-container.git
Cloning into 'ansible-container'...
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

It works however, when you try to clone via https instead of ssh.