### PR TITLE
Add --repository to push subcommand.

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -111,6 +111,10 @@ def subcmd_push_parser(parser, subparser):
                            help=(u'Base URL for your registry. If not provided, '
                                  u'Docker Hub will be used.'),
                            dest='url', default=None)
+    subparser.add_argument('--repository', action='store',
+                           help=(u'Path of the repository to tag and push the image into. Will be appended to '
+                                 u'registry URL. Defaults to the registry username.'),
+                           dest='repository', default=None)
 
 class LoadSubmoduleAction(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):

--- a/container/engine.py
+++ b/container/engine.py
@@ -25,6 +25,12 @@ class BaseEngine(object):
         logger.debug('Initialized with params: %s', params)
         self.params = params
 
+        self.support_init = True
+        self.supports_build = True
+        self.supports_push = True
+        self.supports_run = True
+
+
     def all_hosts_in_orchestration(self):
         """
         List all hosts being orchestrated by the compose engine.
@@ -186,7 +192,7 @@ class BaseEngine(object):
         """
         raise NotImplementedError()
 
-    def push_latest_image(self, host, username):
+    def push_latest_image(self, host, username, **kwargs):
         """
         Push the latest built image for a host to a registry
 
@@ -266,7 +272,7 @@ def cmdrun_push(base_path, engine_name, username=None, password=None, email=None
 
     logger.info('Pushing to repository for user %s', username)
     for host in engine_obj.hosts_touched_by_playbook():
-        engine_obj.push_latest_image(host, username)
+        engine_obj.push_latest_image(host, username, url, **kwargs)
     logger.info('Done!')
 
 


### PR DESCRIPTION
Allow the user to set a custom repository name. Defaults to registry username. Needed in the case of the GKE where the repository name must be the project ID.