### PR TITLE
Add host port for django, otherwise the demo doesn't work.

### DIFF
--- a/example/ansible/container.yml
+++ b/example/ansible/container.yml
@@ -3,7 +3,7 @@ services:
   django:
     image: centos:7
     ports:
-      - "8080"
+      - "8080:8080"
     working_dir: '/django'
     links:
       - postgresql


### PR DESCRIPTION
When the port is defined as '- 8080', compose maps it to a random port on the host. Not very useful, and leaves the demo broken.