### PR TITLE
Use nginx in init command, uncomment the example

### DIFF
--- a/container/templates/ansible/container.j2.yml
+++ b/container/templates/ansible/container.j2.yml
@@ -2,12 +2,9 @@ version: "1"
 services:
   # Add your containers here, specifying the base image you want to build from
   # For example:
-  #
-  # web:
-  #   image: ubuntu:trusty
-  #   ports:
-  #     - "80:80"
-  #   command: ['/usr/sbin/dumb-init', '/usr/bin/apache2ctl', '-D', 'FOREGROUND']
-  #   dev_overrides:
-  #     environment:
-  #       - "DEBUG=1"
+  web:
+    image: nginx
+    ports:
+      - "80:80"
+    environment:
+      - NGINX_PORT=80


### PR DESCRIPTION
Uncomment the example and use NGINX

Rather than use Ubuntu and Apache (resulting in a larger image to
download), use nginx which has larger community support within the
Docker eco-system.

I also uncomment the example so people can use ansible-container
straight away, rather than having to uncomment each line.