### PR TITLE
Error out if main.yml is missing

### DIFF
--- a/container/utils.py
+++ b/container/utils.py
@@ -72,8 +72,10 @@ def assert_initialized(base_path):
     ansible_dir = os.path.normpath(
         os.path.join(base_path, 'ansible'))
     container_file = os.path.join(ansible_dir, 'container.yml')
+    ansible_file = os.path.join(ansible_dir, 'main.yml')
     if not os.path.exists(ansible_dir) or not os.path.isdir(ansible_dir) or \
-            not os.path.exists(container_file) or not os.path.isfile(container_file):
+            not os.path.exists(container_file) or not os.path.isfile(container_file) \
+            or not os.path.exists(ansible_file) or not os.path.isfile(ansible_file):
         raise AnsibleContainerNotInitializedException()
 
 def get_latest_image_for(project_name, host, client):

--- a/test/unit/container/test_utils.py
+++ b/test/unit/container/test_utils.py
@@ -1,0 +1,31 @@
+import shutil
+import tempfile
+from os import path
+import unittest
+import os
+import pytest
+from container.utils import assert_initialized
+from container.exceptions import AnsibleContainerNotInitializedException
+
+
+class TestMissingFiles(unittest.TestCase):
+
+    '''
+    This test class creates a temporary folder with only "main.yml"
+    written out. This tests passses if AnsibleContainerNotInitializedException
+    is correctly raised due to a missing 'container.yml' file.
+    '''
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.ansible_dir = path.join(self.test_dir, "ansible")
+        os.mkdir(self.ansible_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_something(self):
+        f = open(path.join(self.ansible_dir, 'main.yml'), 'w')
+        f.write('')
+        with pytest.raises(AnsibleContainerNotInitializedException):
+            assert_initialized(self.test_dir)


### PR DESCRIPTION
Errors out if main.yml or container.yml is missing when running
`ansible-container build`