### PR TITLE
Don't remove prior image if it is child to new image.

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -459,7 +459,13 @@ class Engine(BaseEngine):
                    force=True)
         logger.info('Cleaning up %s build container...', host)
         client.remove_container(container_id)
-        if purge_last and previous_image_id:
+
+        image_data = client.inspect_image(image_id)
+        parent_sha = ' '
+        if image_data:
+            parent_sha = image_data.get('Parent', ' ')
+
+        if purge_last and previous_image_id and previous_image_id not in parent_sha:
             logger.info('Removing previous image...')
             client.remove_image(previous_image_id, force=True)
 

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -12,7 +12,7 @@ def project_dir(name):
 @pytest.mark.timeout(240)
 def test_build_minimal_docker_container():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'build', cwd=project_dir('minimal'), expect_stderr=True)
+    result = env.run('ansible-container', 'build', '--flatten', cwd=project_dir('minimal'), expect_stderr=True)
     assert "Aborting on container exit" in result.stdout
     assert "Exported minimal-minimal with image ID " in result.stderr
 


### PR DESCRIPTION
This fixes #111. By default images are not being exported and flattened, which makes each build dependent on the prior build, in which case the prior image cannot be removed. 

You can run `ansible-container build --flatten` to break the dependency chain. For example, notice in the output below (created with --flatten) that 'Removing previous build' gets executed. This is because an export/import of the image occurred and there is no longer a dependency on the previous build.

```
ansible-container_1  |
ansible-container_1  | PLAY RECAP *********************************************************************
ansible-container_1  | django                     : ok=15   changed=4    unreachable=0    failed=0
ansible-container_1  | gulp                       : ok=13   changed=4    unreachable=0    failed=0
ansible-container_1  | static                     : ok=10   changed=0    unreachable=0    failed=0
ansible-container_1  |
ansible_ansible-container_1 exited with code 0
Aborting on container exit...
Stopping ansible_static_1 ... done
Stopping ansible_gulp_1 ... done
Stopping ansible_django_1 ... done
Stopping ansible_postgresql_1 ... done
Exporting built containers as images...
Flattening image...
Exported django-admin-gulp with image ID sha256:5ba4bf0274bb2d9855ea4badd58ed739704596c8125436c431e215569959a448
Cleaning up gulp build container...
Removing previous image...
Flattening image...
Exported django-admin-static with image ID sha256:66652aa51e61283c7b7368896a15c7b55d8b89d5a5c9819963ee9c6890826f6d
Cleaning up static build container...
Removing previous image...
Flattening image...
Exported django-admin-django with image ID sha256:faa59f4f5d74fd7309b643ecb0f4ff85b3a7804e753b8ed6ec81b5e5f34357d1
Cleaning up django build container...
Removing previous image...
Cleaning up Ansible Container builder...
```