### PR TITLE
Allow ansible-container to mount with SELinux

### DIFF
--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -8,8 +8,8 @@ ansible-container:
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
   volumes:
-    {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/{% endif %}
-    - {{ base_path }}:/ansible-container/
-    {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/tmp/docker.sock{% endif %}
+    {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
+    - {{ base_path }}:/ansible-container/:Z
+    {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/tmp/docker.sock:Z{% endif %}
   working_dir: /ansible-container/ansible/
 {{ config }}

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -8,8 +8,8 @@ ansible-container:
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
   volumes:
-    {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/{% endif %}
-    - {{ base_path }}:/ansible-container/
+    {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
+    - {{ base_path }}:/ansible-container/:Z
   working_dir: /ansible-container/ansible/
   stdin_open: true
   tty: true


### PR DESCRIPTION
Add a `:Z` suffix so that the ansible build container can
actually see the ansible-container and docker-certs
working directories.

https://docs.docker.com/engine/tutorials/dockervolumes/#volume-labels