### PR TITLE
implement detached mode for run, fix #131

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -91,6 +91,9 @@ def subcmd_run_parser(parser, subparser):
     subparser.add_argument('--production', action='store_true',
                            help=u'Run the production configuration locally',
                            default=False, dest='production')
+    subparser.add_argument('-d', action='store_true',
+                           help=u'Deploy application in detached mode',
+                           dest='detached')
 
 def subcmd_help_parser(parser, subparser):
     return

--- a/container/cli.py
+++ b/container/cli.py
@@ -91,7 +91,7 @@ def subcmd_run_parser(parser, subparser):
     subparser.add_argument('--production', action='store_true',
                            help=u'Run the production configuration locally',
                            default=False, dest='production')
-    subparser.add_argument('-d', action='store_true',
+    subparser.add_argument('-d', '--detached', action='store_true',
                            help=u'Deploy application in detached mode',
                            dest='detached')
 

--- a/container/cli.py
+++ b/container/cli.py
@@ -52,6 +52,7 @@ AVAILABLE_COMMANDS = {'help': 'Display this help message',
                       'init': 'Initialize a new Ansible Container project',
                       'build': 'Build new images based on ansible/container.yml',
                       'run': 'Run and orchestrate built images based on container.yml',
+                      'stop': 'Stop the services defined in container.yml, if deployed',
                       'push': 'Push your built images to a Docker Hub compatible registry',
                       'shipit': 'Generate a deployment playbook to your cloud of choice.'}
 
@@ -94,6 +95,11 @@ def subcmd_run_parser(parser, subparser):
     subparser.add_argument('-d', '--detached', action='store_true',
                            help=u'Deploy application in detached mode',
                            dest='detached')
+
+def subcmd_stop_parser(parser, subparser):
+    subparser.add_argument('service', action='store',
+                           help=u'The specific services you want to stop',
+                           nargs='*')
 
 def subcmd_help_parser(parser, subparser):
     return

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -278,6 +278,11 @@ class Engine(BaseEngine):
         :param hosts: (optional) A list of hosts to limit orchestration to
         :return: The exit status of the builder container (None if it wasn't run)
         """
+        if 'detached' in self.params:
+            if self.params['detached']:
+                detached = True
+            del self.params['detached']
+
         self.temp_dir = temp_dir
         try:
             builder_img_id = self.get_image_id_by_tag(
@@ -317,6 +322,9 @@ class Engine(BaseEngine):
         command_options = self.DEFAULT_COMPOSE_UP_OPTIONS.copy()
         command_options[u'--no-build'] = True
         command_options[u'SERVICE'] = hosts
+        if 'detached' in locals():
+            logger.info('Deploying application in detached mode')
+            command_options[u'-d'] = True
         command_options.update(extra_options)
         project = project_from_options(self.base_path, options)
         command = main.TopLevelCommand(project)

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -269,6 +269,11 @@ class Engine(BaseEngine):
         u'SERVICE': []
     }
 
+    DEFAULT_COMPOSE_STOP_OPTIONS = {
+        u'--timeout': None,
+        u'SERVICE': []
+    }
+
     def orchestrate(self, operation, temp_dir, hosts=[], context={}):
         """
         Execute the compose engine.
@@ -347,6 +352,14 @@ class Engine(BaseEngine):
         """
         return {}
 
+    def terminate_stop_extra_args(self):
+        """
+        Provide extra arguments to provide the orchestrator during stop.
+
+        :return: dictionary
+        """
+        return {}
+
     def orchestrate_galaxy_extra_args(self):
         """
         Provide extra arguments to provide the orchestrator during galaxy calls.
@@ -362,6 +375,41 @@ class Engine(BaseEngine):
         :return: dictionary
         """
         return {'--no-color': True}
+
+    def terminate(self, operation, temp_dir, hosts=[]):
+        self.temp_dir = temp_dir
+        extra_options = getattr(self, 'terminate_%s_extra_args' % operation)()
+        config = getattr(self, 'get_config_for_%s' % operation)()
+        logger.debug('%s' % (config,))
+        config_yaml = yaml_dump(config)
+        logger.debug('Config YAML is')
+        logger.debug(config_yaml)
+        jinja_render_to_temp('%s-docker-compose.j2.yml' % (operation,),
+                             temp_dir,
+                             'docker-compose.yml',
+                             hosts=self.all_hosts_in_orchestration(),
+                             project_name=self.project_name,
+                             base_path=self.base_path,
+                             params=self.params,
+                             api_version=self.api_version,
+                             config=config_yaml,
+                             env=os.environ)
+        options = self.DEFAULT_COMPOSE_OPTIONS.copy()
+        options.update({
+            u'--verbose': self.params['debug'],
+            u'--file': [
+                os.path.join(temp_dir,
+                             'docker-compose.yml')],
+            u'COMMAND': 'stop',
+            u'--project-name': 'ansible'
+        })
+        command_options = self.DEFAULT_COMPOSE_STOP_OPTIONS.copy()
+        command_options[u'SERVICE'] = hosts
+        command_options.update(extra_options)
+        project = project_from_options(self.base_path, options)
+        command = main.TopLevelCommand(project)
+        command.stop(command_options)
+
 
     def _fix_volumes(self, service_name, service_config):
         # If there are volumes defined for this host, we need to create the
@@ -427,6 +475,10 @@ class Engine(BaseEngine):
                     )
                 )
             self._fix_volumes(service, service_config)
+        return compose_config
+
+    def get_config_for_stop(self):
+        compose_config = config_to_compose(self.config)
         return compose_config
 
     def get_config_for_listhosts(self):

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -283,9 +283,8 @@ class Engine(BaseEngine):
         :param hosts: (optional) A list of hosts to limit orchestration to
         :return: The exit status of the builder container (None if it wasn't run)
         """
-        if 'detached' in self.params:
-            if self.params['detached']:
-                detached = True
+        if self.params.get('detached'):
+            is_detached = True
             del self.params['detached']
 
         self.temp_dir = temp_dir
@@ -327,7 +326,7 @@ class Engine(BaseEngine):
         command_options = self.DEFAULT_COMPOSE_UP_OPTIONS.copy()
         command_options[u'--no-build'] = True
         command_options[u'SERVICE'] = hosts
-        if 'detached' in locals():
+        if locals().get('is_detached'):
             logger.info('Deploying application in detached mode')
             command_options[u'-d'] = True
         command_options.update(extra_options)

--- a/container/engine.py
+++ b/container/engine.py
@@ -163,6 +163,23 @@ class BaseEngine(object):
         """
         raise NotImplementedError()
 
+    def terminate(self, operation, temp_dir, hosts=[]):
+        """
+        Stop, remove containers deployed by `orchestrate`.
+
+        :return: dictionary
+        """
+        raise NotImplementedError()
+
+    def terminate_stop_extra_args(self):
+        """
+        Provide extra arguments to provide the orchestrator during stop.
+
+        :return: dictionary
+        """
+        return NotImplementedError
+
+
     def post_build(self, host, version, flatten=True, purge_last=True):
         """
         After orchestrated build, prepare an image from the built container.
@@ -288,6 +305,16 @@ def cmdrun_run(base_path, engine_name, service=[], production=False, **kwargs):
         hosts = service or (engine_obj.all_hosts_in_orchestration())
         engine_obj.orchestrate('run', temp_dir,
                                hosts=hosts)
+
+
+def cmdrun_stop(base_path, engine_name, service=[], **kwargs):
+    assert_initialized(base_path)
+    engine_args = kwargs.copy()
+    engine_args.update(locals())
+    engine_obj = load_engine(**engine_args)
+    with make_temp_dir() as temp_dir:
+        hosts = service or (engine_obj.all_hosts_in_orchestration())
+        engine_obj.terminate('stop', temp_dir, hosts=hosts)
 
 
 def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, **kwargs):

--- a/container/templates/stop-docker-compose.j2.yml
+++ b/container/templates/stop-docker-compose.j2.yml
@@ -1,0 +1,4 @@
+ansible-container:
+  image: tianon/true
+  command: /bin/false
+{{ config }}

--- a/test/integration/projects/minimal_sleep/ansible/container.yml
+++ b/test/integration/projects/minimal_sleep/ansible/container.yml
@@ -1,0 +1,12 @@
+version: "1"
+services:
+  minimal1:
+    image: busybox
+    command: sleep 1d
+    volumes:
+      - '/tmp/volume1'
+  minimal2:
+    image: busybox
+    command: sleep 1d
+    volumes:
+      - '/tmp/volume2'

--- a/test/integration/projects/minimal_sleep/ansible/main.yml
+++ b/test/integration/projects/minimal_sleep/ansible/main.yml
@@ -1,0 +1,3 @@
+- hosts: all
+  gather_facts: false
+  tasks:

--- a/test/integration/projects/minimal_sleep/ansible/requirements.txt
+++ b/test/integration/projects/minimal_sleep/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.8.0

--- a/test/integration/test_fast.py
+++ b/test/integration/test_fast.py
@@ -35,6 +35,12 @@ def test_help_option_shows_help_for_run_command():
     assert "usage: ansible-container run" in result.stdout
 
 
+def test_help_option_shows_help_for_stop_command():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', 'stop', '--help')
+    assert "usage: ansible-container stop" in result.stdout
+
+
 def test_help_option_shows_help_for_help_command():
     env = ScriptTestEnvironment()
     result = env.run('ansible-container', 'help', '--help')

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -23,6 +23,32 @@ def test_run_minimal_docker_container():
     assert "ansible_minimal_1 exited with code 0" in result.stdout
 
 
+def test_run_minimal_docker_container_in_detached_mode():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal'), expect_stderr=True)
+    assert "Deploying application in detached mode" in result.stderr
+
+
+@pytest.mark.timeout(240)
+def test_stop_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'build', '--flatten',
+            cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'stop', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Stopping ansible_minimal1_1 ... done" in result.stderr
+    assert "Stopping ansible_minimal2_1 ... done" in result.stderr
+
+
+def test_stop_service_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'stop', 'minimal1',
+                     cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Stopping ansible_minimal1_1 ... done" in result.stderr
+    assert "Stopping ansible_minimal2_1 ... done" not in result.stderr
+
+
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()
 #    result = env.run('ansible-container', 'shipit', 'kube', cwd=project_dir('minimal'), expect_error=True)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Issue #91 and #131 talked about the need of deploying the application in detached mode, which is what I have attempted to do in this PR.

Since `docker.engine.orchestrate` calls `get_config_for_...`, which in turn calls `orchestrate` again, I had to remove `self.params['detached']` so that `get_config_for_...` does not run in detached mode; I set a `detached` flag to True, which I use in the end before `command.up` is executed to pass `-d` to `command.up`

```
Before:
# ansible-container run -d                       
usage: ansible-container [-h] [--debug] [--engine ENGINE_NAME]
                         [--project BASE_PATH]
                         {run,help,shipit,init,build,push} ...
ansible-container: error: unrecognized arguments: -d
```

```
After:
# ansible-container run -d
Attaching to ansible_ansible-container_1
Cleaning up Ansible Container builder...
Deploying application in detached mode

# docker ps
CONTAINER ID        IMAGE                      COMMAND                  CREATED             STATUS              PORTS                          NAMES
ec0b6f5ab126        example-webclient:latest   "./tmp/client.sh"        11 minutes ago      Up 10 minutes                                      ansible_webclient_1
33b1acd02827        example-webserver:latest   "/usr/sbin/apachectl "   11 minutes ago      Up 10 minutes       80/tcp, 0.0.0.0:80->8080/tcp   ansible_webserver_1
```