### PR TITLE
Feature/custom builder volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
   - sudo apt-get update -qq
   - sudo apt-get install -y shellcheck
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" docker-engine
+  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" docker-engine=1.11.2~trusty
 
 install:
   - pip install -r requirements.txt -r test/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
   - sudo apt-get update -qq
   - sudo apt-get install -y shellcheck
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" docker-engine=1.11.2~trusty
+  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine=1.11.2-0~trusty
 
 install:
   - pip install -r requirements.txt -r test/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - docker version
   - docker-compose version
   - export ANSIBLE_CONTAINER_PATH=${PWD}
+  - cd test/local
   - ansible-container build --with-variables ANSIBLE_CONTAINER_PATH=${ANSIBLE_CONTAINER_PATH} 
   - ansible-container run 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,8 @@ script:
   - python setup.py develop
   - docker version
   - docker-compose version
-  - export ANSIBLE_CONTAINER_PATH=${PWD}
-  - cd test/local
-  - ansible-container build --with-variables ANSIBLE_CONTAINER_PATH=${ANSIBLE_CONTAINER_PATH} 
-  - docker images
-  - ansible-container run 
+  - docker info
+  - test/run.sh  
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -F unit        -f test/reports/unit/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - export ANSIBLE_CONTAINER_PATH=${PWD}
   - cd test/local
   - ansible-container build --with-variables ANSIBLE_CONTAINER_PATH=${ANSIBLE_CONTAINER_PATH} 
+  - docker images
   - ansible-container run 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ script:
   - python setup.py develop
   - docker version
   - docker-compose version
-  - test/utils/run_tests.sh
+  - export ANSIBLE_CONTAINER_PATH=${PWD}
+  - ansible-container build --with-variables ANSIBLE_CONTAINER_PATH=${ANSIBLE_CONTAINER_PATH} 
+  - ansible-container run 
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -F unit        -f test/reports/unit/coverage.xml

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,4 +23,22 @@ observe the following when submitting a PR:
 Examples of working Ansible Container playbooks will be very useful! Please feel free to provide Pull Requests linking
 to examples from your own repos in [EXAMPLES.md](./EXAMPLES.md) or submit them to [ansible-container-examples](https://github.com/ansible/ansible-container-examples).
 
+## Running tests
+
+Unit and integration tests are found in the *test* directory. Running tests locally requires having ansible-container installed. Execute tests from within 
+the local copy of the ansible-container repo by running *test/run.sh*:
+
+```
+$ cd ansible-container
+$ ./test/run.sh 
+```
+
+If the local-test image does not exist, the script will create it using `ansible-container build` against the *test/local* project. Once the image
+is availabe tests are executed within a container via `ansible-container run`. Subsequent runs of the script will use the existing local-test image 
+to mount the local copy of ansible-container and execute tests.
+
+This is the same script and test execution that occurs on Travis. So, if tests run successfully in your local environment, they *should* run 
+successfully on Travis. 
+
 Thanks for trying out Ansible Container!
+

--- a/container/cli.py
+++ b/container/cli.py
@@ -78,6 +78,11 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--local-builder', action='store_true',
                            help=u'Instead of using the Ansible Builder Container '
                                 u'image from Docker Hub, generate one locally.')
+    subparser.add_argument('--with-volumes', action='append', nargs='+',
+                           help=u'Mount one or more volumes to the Ansible Builder Container.'
+                                u'Separate volumes with commas. Format volumes as: '
+                                u'/path/to/mount:/container/mount[:permissions]. Permissions '
+                                u'can be one of: ro, rw, z, Z.')
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '

--- a/container/cli.py
+++ b/container/cli.py
@@ -86,6 +86,10 @@ def subcmd_build_parser(parser, subparser):
                            help=u'Define one or more environment variables in the Ansible '
                                 u'Builder Container. Format is key=value. Separate multiple pairs'
                                 u'with a space.')
+    subparser.add_argument('--save-build-container', action='store_true',
+                           help=u'Leave the build container untouched on build completion. Normally '
+                                u'the build is removed after the build completes. Use for debugging '
+                                u'and testing.', default=False)
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '

--- a/container/cli.py
+++ b/container/cli.py
@@ -80,16 +80,15 @@ def subcmd_build_parser(parser, subparser):
                                 u'image from Docker Hub, generate one locally.')
     subparser.add_argument('--with-volumes', '-v', action='append', nargs='+',
                            help=u'Mount one or more volumes to the Ansible Builder Container. '
-                                u'Specify volumes using the same format as the doker run -v option. '
-                                u'Separate multiple volumes with a space.')
+                                u'Specify volumes as strings using the Docker volume format. '
+                                u'Separate multiple volume strings with spaces.')
     subparser.add_argument('--with-variables', '-e', action='append', nargs='+',
                            help=u'Define one or more environment variables in the Ansible '
-                                u'Builder Container. Format is key=value. Separate multiple pairs'
-                                u'with a space.')
+                                u'Builder Container. Format each variable as a key=value string. '
+                                u'Separate multiple variable strings with spaces.')
     subparser.add_argument('--save-build-container', action='store_true',
-                           help=u'Leave the build container untouched on build completion. Normally '
-                                u'the build is removed after the build completes. Use for debugging '
-                                u'and testing.', default=False)
+                           help=u'Leave the Ansible Builder Container intact upon build completion. '
+                                u'Use for debugging and testing.', default=False)
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '

--- a/container/cli.py
+++ b/container/cli.py
@@ -78,11 +78,14 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--local-builder', action='store_true',
                            help=u'Instead of using the Ansible Builder Container '
                                 u'image from Docker Hub, generate one locally.')
-    subparser.add_argument('--with-volumes', action='append', nargs='+',
-                           help=u'Mount one or more volumes to the Ansible Builder Container.'
-                                u'Separate volumes with commas. Format volumes as: '
-                                u'/path/to/mount:/container/mount[:permissions]. Permissions '
-                                u'can be one of: ro, rw, z, Z.')
+    subparser.add_argument('--with-volumes', '-v', action='append', nargs='+',
+                           help=u'Mount one or more volumes to the Ansible Builder Container. '
+                                u'Specify volumes using the same format as the doker run -v option. '
+                                u'Separate multiple volumes with a space.')
+    subparser.add_argument('--with-variables', '-e', action='append', nargs='+',
+                           help=u'Define one or more environment variables in the Ansible '
+                                u'Builder Container. Format is key=value. Separate multiple pairs'
+                                u'with a space.')
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '
@@ -137,6 +140,11 @@ def subcmd_shipit_parser(parser, subparser):
         engine_obj.add_options(engine_parser)
 
 def commandline():
+
+    # default_base_path = os.getcwd()
+    # if os.environ.get('ANSIBLE_CONTAINER_PROJECT'):
+    #     default_base_path = os.environ['ANSIBLE_CONTAINER_PROJECT']
+
     parser = argparse.ArgumentParser(description=u'Build, orchestrate, run, and '
                                                  u'ship Docker containers with '
                                                  u'Ansible playbooks')

--- a/container/engine.py
+++ b/container/engine.py
@@ -266,6 +266,7 @@ def cmdrun_init(base_path, **kwargs):
 
 def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_builder=False,
                  rebuild=False, ansible_options='', **kwargs):
+
     engine_args = kwargs.copy()
     engine_args.update(locals())
     engine_obj = load_engine(**engine_args)
@@ -279,7 +280,13 @@ def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_bu
         logger.info('Starting %s engine to build your images...'
                     % engine_obj.orchestrator_name)
         touched_hosts = engine_obj.hosts_touched_by_playbook()
-        engine_obj.orchestrate('build', temp_dir, context=dict(rebuild=rebuild))
+        with_volumes = []
+        if kwargs.get('with_volumes'):
+            for vol in kwargs.pop('with_volumes'):
+                with_volumes += vol
+            logger.debug("volumes: %s" % ','.join(with_volumes))
+        engine_obj.orchestrate('build', temp_dir, context=dict(rebuild=rebuild,
+                                                               with_volumes=with_volumes))
         if not engine_obj.build_was_successful():
             logger.error('Ansible playbook run failed.')
             logger.info('Cleaning up Ansible Container builder...')

--- a/container/engine.py
+++ b/container/engine.py
@@ -266,6 +266,7 @@ def cmdrun_init(base_path, **kwargs):
 
 def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_builder=False,
                  rebuild=False, ansible_options='', **kwargs):
+    save_build_container = kwargs.pop('save_build_container')
     engine_args = kwargs.copy()
     engine_args.update(locals())
     engine_obj = load_engine(**engine_args)
@@ -294,18 +295,20 @@ def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_bu
                                                                with_variables=with_variables))
         if not engine_obj.build_was_successful():
             logger.error('Ansible playbook run failed.')
-            logger.info('Cleaning up Ansible Container builder...')
-            builder_container_id = engine_obj.get_builder_container_id()
-            engine_obj.remove_container_by_id(builder_container_id)
+            if not save_build_container:
+                logger.info('Cleaning up Ansible Container builder...')
+                builder_container_id = engine_obj.get_builder_container_id()
+                engine_obj.remove_container_by_id(builder_container_id)
             raise RuntimeError(u'Ansible build failed')
         # Cool - now export those containers as images
         version = datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
         logger.info('Exporting built containers as images...')
         for host in touched_hosts:
             engine_obj.post_build(host, version, flatten=flatten, purge_last=purge_last)
-        logger.info('Cleaning up Ansible Container builder...')
-        builder_container_id = engine_obj.get_builder_container_id()
-        engine_obj.remove_container_by_id(builder_container_id)
+        if not save_build_container:
+            logger.info('Cleaning up Ansible Container builder...')
+            builder_container_id = engine_obj.get_builder_container_id()
+            engine_obj.remove_container_by_id(builder_container_id)
 
 
 def cmdrun_run(base_path, engine_name, service=[], production=False, **kwargs):

--- a/container/engine.py
+++ b/container/engine.py
@@ -266,7 +266,6 @@ def cmdrun_init(base_path, **kwargs):
 
 def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_builder=False,
                  rebuild=False, ansible_options='', **kwargs):
-
     engine_args = kwargs.copy()
     engine_args.update(locals())
     engine_obj = load_engine(**engine_args)
@@ -285,8 +284,14 @@ def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_bu
             for vol in kwargs.pop('with_volumes'):
                 with_volumes += vol
             logger.debug("volumes: %s" % ','.join(with_volumes))
+        with_variables = []
+        if kwargs.get('with_variables'):
+            for env_var in kwargs.pop('with_variables'):
+                with_variables += env_var
+            logger.debug("env variables: %s" % ','.join(with_variables))
         engine_obj.orchestrate('build', temp_dir, context=dict(rebuild=rebuild,
-                                                               with_volumes=with_volumes))
+                                                               with_volumes=with_volumes,
+                                                               with_variables=with_variables))
         if not engine_obj.build_was_successful():
             logger.error('Ansible playbook run failed.')
             logger.info('Cleaning up Ansible Container builder...')

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -11,5 +11,6 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/tmp/docker.sock:Z{% endif %}
+    {% if with_volumes %}{% for vol in with_volumes %}- {{ vol }}{% endfor %}{% endif %}
   working_dir: /ansible-container/ansible/
 {{ config }}

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -7,7 +7,9 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- DOCKER_CERT_PATH=/docker-certs/{% endif %}
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
-    {% if with_variables %}{% for env_var in with_variables %}- {{ env_var }}{% endfor %}{% endif %}
+    {% if with_variables %}{% for env_var in with_variables %}
+    - {{ env_var }}
+    {% endfor %}{% endif %}
   volumes:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -7,6 +7,7 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- DOCKER_CERT_PATH=/docker-certs/{% endif %}
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
+    {% if with_variables %}{% for env_var in with_variables %}- {{ env_var }}{% endfor %}{% endif %}
   volumes:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,19 @@
+## Running tests
+
+Unit and integration tests live here. Running tests locally requires having ansible-container installed. Execute tests from within 
+the local copy of the ansible-container repo by running *test/run.sh*:
+
+```
+$ cd ansible-container
+$ ./test/run.sh 
+```
+
+If the local-test image does not exist, the script will create it using `ansible-container build` against the *test/local* project. Once the image
+is availabe tests are executed within a container via `ansible-container run`. Subsequent runs of the script will use the existing local-test image 
+to mount the local copy of ansible-container and execute tests.
+
+This is the same script and test execution that occurs on Travis. So, if tests run successfully in your local environment, they *should* run 
+successfully on Travis. 
+
+Thanks for trying out Ansible Container!
+

--- a/test/local/README.md
+++ b/test/local/README.md
@@ -1,0 +1,17 @@
+# Test Local
+
+This little project runs the unit and integration tests in a container.
+
+It requires mounting a local copy of the ansible-container project to a path on the container that exactly matches the 
+host path. Notice in ansible/container.yml the local copy of ansible-container is assumed to live at 
+/projects/ansible-container, and it mounts that path to the container as /projects/ansible-container. The host and 
+container paths match, and things work. If the paths don't match, it won't work as the Docker daemon (which is 
+running on the host) will complain that it cannot find the path to mount the project.
+
+Once you work out how to mount the local copy of ansible-container, the following will execute tests: 
+
+```
+$ cd ansible-continer/test/local
+$ ansible-container build 
+$ ansible-container run
+```

--- a/test/local/ansible/container.yml
+++ b/test/local/ansible/container.yml
@@ -1,0 +1,14 @@
+version: "1"
+services:
+  test:
+    image: python:2.7
+    volumes:
+       - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}" 
+       - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: "${ANSIBLE_CONTAINER_PATH}" 
+    environment:
+      VIRTUAL_ENV: /usr/local  
+    command:
+      - ./test/utils/run_tests.sh
+
+registries: {}

--- a/test/local/ansible/main.yml
+++ b/test/local/ansible/main.yml
@@ -26,12 +26,10 @@
     - name: Update cache again
       apt: update_cache=yes
 
-    - name: Install docker engine
-      apt: name=docker-engine version=1.11.2-0~jessie
-
-    - name: Install other packages 
+    - name: Install apt packages 
       apt: name="{{ item }}"
       with_items:
+        - docker-engine=1.11.2-0~jessie
         - shellcheck
 
     - name: Install python packages 

--- a/test/local/ansible/main.yml
+++ b/test/local/ansible/main.yml
@@ -26,13 +26,12 @@
     - name: Update cache again
       apt: update_cache=yes
 
-    - name: Install apt packages
+    - name: Install docker engine
+      apt: name=docker-engine version=1.11.2-0~jessie
+
+    - name: Install other packages 
       apt: name="{{ item }}"
       with_items:
-        # - python-setuptools
-        # - python-dev
-        # - python-pip
-        - docker-engine
         - shellcheck
 
     - name: Install python packages 

--- a/test/local/ansible/main.yml
+++ b/test/local/ansible/main.yml
@@ -1,0 +1,54 @@
+- hosts: test 
+  gather_facts: no
+  vars:
+    project_path: "{{ lookup('env','ANSIBLE_CONTAINER_PATH') }}"
+  tasks:
+    - name: Update apt cache
+      apt: update_cache=yes
+
+    - name: Install https transport
+      apt: name="{{ item }}"
+      with_items:
+        - apt-transport-https
+        - ca-certificates
+
+    - name: Add apt key 
+      command: apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+    - name: Touch docker.list
+      file: name=/etc/apt/sources.list.d/docker.list state=touch
+
+    - name: Add repo to docker.list
+      lineinfile:
+        dest: /etc/apt/sources.list.d/docker.list
+        line: "deb https://apt.dockerproject.org/repo debian-jessie main"
+
+    - name: Update cache again
+      apt: update_cache=yes
+
+    - name: Install apt packages
+      apt: name="{{ item }}"
+      with_items:
+        # - python-setuptools
+        # - python-dev
+        # - python-pip
+        - docker-engine
+        - shellcheck
+
+    - name: Install python packages 
+      pip: name="{{ item }}"
+      with_items:
+        - pytest
+        - pytest-timeout
+        - pytest-cov
+        - markupsafe
+        - docker-compose
+        - scripttest
+
+    - name: Install python requirements
+      pip: requirements="{{ project_path }}/requirements.txt"
+
+    - name: Install ansible-container from source
+      command: python ./setup.py develop
+      args:
+        chdir: "{{ project_path }}" 

--- a/test/run.sh
+++ b/test/run.sh
@@ -9,7 +9,7 @@
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '..')))")
 export ANSIBLE_CONTAINER_PATH=${source_root}
 
-image_exists=$(docker images local-test:latest)
+image_exists=$(docker images local-test:latest | wc -l)
 if [ "${image_exists}" -le "1" ]; then
    ansible-container --project "${source_root}/test/local" build --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
 fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# run.sh 
+#
+# Run unit and integration tests via container. Provides a one mechanism for running tests locally and 
+# on Travis.
+#
+#
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '..')))")
+export ANSIBLE_CONTAINER_PATH=${source_root}
+
+image_exists=$(docker images local-test:latest)
+if [ "${image_exists}" -le "1" ]; then
+   ansible-container --project "${source_root}/test/local" build --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
+fi
+
+ansible-container --project "${source_root}/test/local" run


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
**Adds** the following to the *build* command:

```
 --with-volumes WITH_VOLUMES [WITH_VOLUMES ...], -v WITH_VOLUMES [WITH_VOLUMES ...]
                        Mount one or more volumes to the Ansible Builder
                        Container. Specify volumes using the Docker volume
                        format string. Separate multiple volume strings with
                        spaces.
  --with-variables WITH_VARIABLES [WITH_VARIABLES ...], -e WITH_VARIABLES [WITH_VARIABLES ...]
                        Define one or more environment variables in the
                        Ansible Builder Container. Format each variable as a
                        key=value string. Separate multiple variable strings
                        with spaces.
  --save-build-container
                        Leave the Ansible Builder Container intact upon build
                        completion. Use for debugging and testing.
```

**Makes** the tests runnable both locally and on Travis using a single command. Yes! To run tests:

```
$ /path/to/local/ansible-container/test/run.sh
```
Tests will execute inside of a container. If the local-test image does not already exist, the script will first build it using `ansible-container build`. It then runs the tests using `ansible-container run`.  Relies on the new --with-variables to make the magic work. The project for maintaining the image is found in test/local.

**Adds** integration tests for --with-variables and --with-volumes.
