### PR TITLE
implement force stopping containers, add tests

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -111,6 +111,9 @@ def subcmd_stop_parser(parser, subparser):
     subparser.add_argument('service', action='store',
                            help=u'The specific services you want to stop',
                            nargs='*')
+    subparser.add_argument('-f', '--force', action='store_true',
+                           help=u'Force stop running containers',
+                           dest='force')
 
 def subcmd_help_parser(parser, subparser):
     return

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -407,7 +407,10 @@ class Engine(BaseEngine):
         command_options.update(extra_options)
         project = project_from_options(self.base_path, options)
         command = main.TopLevelCommand(project)
-        command.stop(command_options)
+        if self.params.get('force'):
+            command.kill(command_options)
+        else:
+            command.stop(command_options)
 
 
     def _fix_volumes(self, service_name, service_config):

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -73,6 +73,25 @@ def test_stop_service_minimal_docker_container():
     assert "Stopping ansible_minimal2_1 ... done" not in result.stderr
 
 
+def test_force_stop_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'stop', '--force',
+                     cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Killing ansible_minimal1_1 ... done" in result.stderr
+    assert "Killing ansible_minimal2_1 ... done" in result.stderr
+
+
+def test_force_stop_service_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'stop', '--force', 'minimal1',
+                     cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Killing ansible_minimal1_1 ... done" in result.stderr
+    assert "Killing ansible_minimal2_1 ... done" not in result.stderr
+
+
+
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()
 #    result = env.run('ansible-container', 'shipit', 'kube', cwd=project_dir('minimal'), expect_error=True)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
- Implemented killing of running services by passing `ansible-container stop --force <service>`
- Added tests for this behavior

```bash
# ansible-container stop --force
Killing ansible_webclient_1 ... done
Killing ansible_webserver_1 ... done
```