### PR TITLE
implement ansible-container restart, add tests

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -53,6 +53,7 @@ AVAILABLE_COMMANDS = {'help': 'Display this help message',
                       'build': 'Build new images based on ansible/container.yml',
                       'run': 'Run and orchestrate built images based on container.yml',
                       'stop': 'Stop the services defined in container.yml, if deployed',
+                      'restart': 'Restart the services defined in container.yml',
                       'push': 'Push your built images to a Docker Hub compatible registry',
                       'shipit': 'Generate a deployment playbook to your cloud of choice.'}
 
@@ -117,6 +118,11 @@ def subcmd_stop_parser(parser, subparser):
     subparser.add_argument('-f', '--force', action='store_true',
                            help=u'Force stop running containers',
                            dest='force')
+
+def subcmd_restart_parser(parser, subparser):
+    subparser.add_argument('service', action='store',
+                           help=u'The specific services you want to restart',
+                           nargs='*')
 
 def subcmd_help_parser(parser, subparser):
     return

--- a/container/engine.py
+++ b/container/engine.py
@@ -179,6 +179,24 @@ class BaseEngine(object):
         """
         return NotImplementedError
 
+    def restart(self, operation, temp_dir, hosts=[]):
+        """
+        Restart containers deployed by `orchestrate`, deploys if not deployed
+
+        :param operation: 'restart'
+        :param temp_dir: A temporary directory usable as workspace
+        :param hosts: (optional) A list of hosts to limit orchestration to
+        """
+
+        return NotImplementedError
+
+    def restart_restart_extra_args(self):
+        """
+        Provide extra arguments to provide the orchestrator during restart.
+
+        :return: dictionary
+        """
+        return NotImplementedError
 
     def post_build(self, host, version, flatten=True, purge_last=True):
         """
@@ -330,6 +348,16 @@ def cmdrun_stop(base_path, engine_name, service=[], **kwargs):
     with make_temp_dir() as temp_dir:
         hosts = service or (engine_obj.all_hosts_in_orchestration())
         engine_obj.terminate('stop', temp_dir, hosts=hosts)
+
+
+def cmdrun_restart(base_path, engine_name, service=[], **kwargs):
+    assert_initialized(base_path)
+    engine_args = kwargs.copy()
+    engine_args.update(locals())
+    engine_obj = load_engine(**engine_args)
+    with make_temp_dir() as temp_dir:
+        hosts = service or (engine_obj.all_hosts_in_orchestration())
+        engine_obj.restart('restart', temp_dir, hosts=hosts)
 
 
 def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, **kwargs):

--- a/container/templates/restart-docker-compose.j2.yml
+++ b/container/templates/restart-docker-compose.j2.yml
@@ -1,0 +1,4 @@
+ansible-container:
+  image: tianon/true
+  command: /bin/false
+{{ config }}

--- a/test/integration/test_fast.py
+++ b/test/integration/test_fast.py
@@ -41,6 +41,12 @@ def test_help_option_shows_help_for_stop_command():
     assert "usage: ansible-container stop" in result.stdout
 
 
+def test_help_option_shows_help_for_restart_command():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', 'restart', '--help')
+    assert "usage: ansible-container restart" in result.stdout
+
+
 def test_help_option_shows_help_for_help_command():
     env = ScriptTestEnvironment()
     result = env.run('ansible-container', 'help', '--help')

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -91,6 +91,23 @@ def test_force_stop_service_minimal_docker_container():
     assert "Killing ansible_minimal2_1 ... done" not in result.stderr
 
 
+def test_restart_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'restart', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Restarting ansible_minimal1_1 ... done" in result.stderr
+    assert "Restarting ansible_minimal2_1 ... done" in result.stderr
+    env.run('ansible-container', 'stop', cwd=project_dir('minimal_sleep'),
+            expect_stderr=True)
+
+
+def test_restart_service_minimal_docker_container():
+    env = ScriptTestEnvironment()
+    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    result = env.run('ansible-container', 'restart', 'minimal1', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    assert "Restarting ansible_minimal1_1 ... done" in result.stderr
+    assert "Restarting ansible_minimal2_1 ... done" not in result.stderr
+
 
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()


### PR DESCRIPTION
Supersedes #158 

##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
This implements `ansible-container restart <service>` command.
Added tests.

```bash
# ansible-container restart
Restarting ansible_webclient_1 ... done
Restarting ansible_webserver_1 ... done
```