### PR TITLE
Don't mount basepath directly, put it in a data container instead

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -89,6 +89,9 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--save-build-container', action='store_true',
                            help=u'Leave the Ansible Builder Container intact upon build completion. '
                                 u'Use for debugging and testing.', default=False)
+    subparser.add_argument('--with-data-container', action='store_true',
+                           help=u'Put ansible code in a separate data container'
+                                u'Use for remote docker hosts.', default=False)
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -10,10 +10,23 @@ ansible-container:
     {% if with_variables %}{% for env_var in with_variables %}
     - {{ env_var }}
     {% endfor %}{% endif %}
+  {% if not env.DOCKER_HOST or env.DOCKER_CERT_PATH or not with_data_container %}
   volumes:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
-    - {{ base_path }}:/ansible-container/:Z
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/tmp/docker.sock:Z{% endif %}
+    {% if not with_data_container %}
+    - {{ base_path }}:/ansible-container/:Z
+    {% endif %}
     {% if with_volumes %}{% for vol in with_volumes %}- {{ vol }}{% endfor %}{% endif %}
+  {% endif %}
+  {% if with_data_container %}
+  volumes_from:
+    - ansible-data
+  {% endif %}
   working_dir: /ansible-container/ansible/
+{% if with_data_container %}
+ansible-data:
+  image: "{{ data_img_id }}"
+  entrypoint: sh -c "while true; do sleep 1; done"
+{% endif %}
 {{ config }}

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -7,10 +7,23 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- DOCKER_CERT_PATH=/docker-certs/{% endif %}
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
+  {% if env.DOCKER_CERT_PATH or not with_data_container %}
   volumes:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
+    {% if not with_data_container %}
     - {{ base_path }}:/ansible-container/:Z
+    {% endif %}
+  {% endif %}
+  {% if with_data_container %}
+  volumes_from:
+    - ansible-data
+  {% endif %}
   working_dir: /ansible-container/ansible/
   stdin_open: true
   tty: true
+{% if with_data_container %}
+ansible-data:
+  image: "{{ data_img_id }}"
+  entrypoint: sh -c "while true; do sleep 1; done"
+{% endif %}
 {{ config }}

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -28,6 +28,13 @@ def test_build_with_variables():
     assert "foo=bar" in result.stdout
     assert "bar=baz" in result.stdout
 
+def test_build_minimal_docker_container_with_data_container():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', '--debug', 'build', '--with-data-container', cwd=project_dir('minimal'), expect_stderr=True)
+    assert "Aborting on container exit" in result.stdout
+    assert "Exported minimal-minimal with image ID " in result.stderr
+    assert "Stopping ansible_ansible-data_1 ... done" in result.stderr
+
 def test_build_with_volumes():
     env = ScriptTestEnvironment()
     volume_string = "{0}:{1}:{2}".format(os.getcwd(), '/projectdir', 'ro')

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -12,13 +12,13 @@ def project_dir(name):
 @pytest.mark.timeout(240)
 def test_build_minimal_docker_container():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'build', '--flatten', cwd=project_dir('minimal'), expect_stderr=True)
+    result = env.run('ansible-container', '--debug', 'build', '--flatten', cwd=project_dir('minimal'), expect_stderr=True)
     assert "Aborting on container exit" in result.stdout
     assert "Exported minimal-minimal with image ID " in result.stderr
 
 def test_build_with_variables():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'build', '--save-build-container', '--with-variables', 'foo=bar',
+    result = env.run('ansible-container', '--debug', 'build', '--save-build-container', '--with-variables', 'foo=bar',
                      'bar=baz', cwd=project_dir('minimal'), expect_stderr=True)
     assert "Aborting on container exit" in result.stdout
     assert "Exported minimal-minimal with image ID " in result.stderr
@@ -31,7 +31,7 @@ def test_build_with_variables():
 def test_build_with_volumes():
     env = ScriptTestEnvironment()
     volume_string = "{0}:{1}:{2}".format(os.getcwd(), '/projectdir', 'ro')
-    result = env.run('ansible-container', 'build', '--save-build-container', '--with-volumes', volume_string,
+    result = env.run('ansible-container', '--debug', 'build', '--save-build-container', '--with-volumes', volume_string,
                      cwd=project_dir('minimal'), expect_stderr=True)
     assert "Aborting on container exit" in result.stdout
     assert "Exported minimal-minimal with image ID " in result.stderr
@@ -43,22 +43,22 @@ def test_build_with_volumes():
 
 def test_run_minimal_docker_container():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'run', cwd=project_dir('minimal'), expect_stderr=True)
+    result = env.run('ansible-container', '--debug', 'run', cwd=project_dir('minimal'), expect_stderr=True)
     assert "ansible_minimal_1 exited with code 0" in result.stdout
 
 
 def test_run_minimal_docker_container_in_detached_mode():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal'), expect_stderr=True)
+    result = env.run('ansible-container', '--debug', 'run', '--detached', cwd=project_dir('minimal'), expect_stderr=True)
     assert "Deploying application in detached mode" in result.stderr
 
 
 @pytest.mark.timeout(240)
 def test_stop_minimal_docker_container():
     env = ScriptTestEnvironment()
-    env.run('ansible-container', 'build', '--flatten',
+    env.run('ansible-container', '--debug', 'build', '--flatten',
             cwd=project_dir('minimal_sleep'), expect_stderr=True)
-    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    env.run('ansible-container', '--debug', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
     result = env.run('ansible-container', 'stop', cwd=project_dir('minimal_sleep'), expect_stderr=True)
     assert "Stopping ansible_minimal1_1 ... done" in result.stderr
     assert "Stopping ansible_minimal2_1 ... done" in result.stderr
@@ -66,7 +66,7 @@ def test_stop_minimal_docker_container():
 
 def test_stop_service_minimal_docker_container():
     env = ScriptTestEnvironment()
-    env.run('ansible-container', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
+    env.run('ansible-container', '--debug', 'run', '--detached', cwd=project_dir('minimal_sleep'), expect_stderr=True)
     result = env.run('ansible-container', 'stop', 'minimal1',
                      cwd=project_dir('minimal_sleep'), expect_stderr=True)
     assert "Stopping ansible_minimal1_1 ... done" in result.stderr


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
ansible-container mounts ```base_path``` directly, which might be dangerous. We should pack the tarball of ```ansible/``` folder in a container, export it as a volume and mount it in ```ansible-container```

This also enables using ansible-containers on remote docker hosts.