### PR TITLE
In post build steps always send string to image Cmd

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -511,10 +511,13 @@ class Engine(BaseEngine):
         previous_image_id, previous_image_buildstamp = get_latest_image_for(
             self.project_name, host, client
         )
+        cmd = self.config['services'][host].get('command', '')
+        if isinstance(self.config['services'][host].get('command'), list):
+            cmd = ' '.join(self.config['services'][host]['command'])
         image_config = dict(
             USER=self.config['services'][host].get('user', 'root'),
             WORKDIR=self.config['services'][host].get('working_dir', '/'),
-            CMD=self.config['services'][host].get('command', '')
+            CMD=cmd
         )
         if flatten:
             logger.info('Flattening image...')


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Fixes #171 build- puts invalid command value in image Config.Cmd during post build steps. 

In the post build steps, if the service command is an array, joins the array elements into a string. 

Prior to this fix the Config.Cmd was producing:

```
"Cmd": [
    "/bin/sh",
    "-c",
    "['/root/start.sh', 'now']"
],
```

With the changes included in this PR the Config.Cmd is set to:

```
"Cmd": [
    "/bin/sh",
    "-c",
    "/root/start.sh",
   "now"
],
```