### PR TITLE
Surface the test container's exit status. Add missing --remove-orphan…

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -106,6 +106,9 @@ def subcmd_run_parser(parser, subparser):
     subparser.add_argument('-d', '--detached', action='store_true',
                            help=u'Deploy application in detached mode',
                            dest='detached')
+    subparser.add_argument('-o', '--remove-orphans', action='store_true',
+                           help=u'Remove containers for services not defined in container.yml.',
+                           default=False, dest='remove_orphans')
 
 def subcmd_stop_parser(parser, subparser):
     subparser.add_argument('service', action='store',

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -321,11 +321,13 @@ class Engine(BaseEngine):
                              'docker-compose.yml')],
             u'COMMAND': 'up',
             u'ARGS': ['--no-build'] + hosts,
-            u'--project-name': 'ansible'
+            u'--project-name': 'ansible',
         })
         command_options = self.DEFAULT_COMPOSE_UP_OPTIONS.copy()
         command_options[u'--no-build'] = True
         command_options[u'SERVICE'] = hosts
+        command_options[u'--remove-orphans'] = self.params.get('remove_orphans', False)
+
         if locals().get('is_detached'):
             logger.info('Deploying application in detached mode')
             command_options[u'-d'] = True

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,3 +15,5 @@ if [ "${image_exists}" -le "1" ]; then
 fi
 
 ansible-container --project "${source_root}/test/local" run
+status=$(docker inspect --format="{{ .State.ExitCode }}" ansible_test_1)
+exit "${status}"


### PR DESCRIPTION
##### ISSUE TYPE
 Bugfix Pull Request
 
##### SUMMARY
Contains the following fixes:

- Add --remove-orphans option to the run command.
- Update test/run.sh to exit with the same status as the test container.