### PR TITLE
Jinja2 template rendering in container.yml

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -97,6 +97,7 @@ def subcmd_build_parser(parser, subparser):
                                 u'prefix your extra options. Use this feature with '
                                 u'caution.', default=u'', nargs='*')
 
+
 def subcmd_run_parser(parser, subparser):
     subparser.add_argument('service', action='store',
                            help=u'The specific services you want to run',
@@ -171,6 +172,10 @@ def commandline():
     parser.add_argument('--project', '-p', action='store', dest='base_path',
                         help=u'Specify a path to your project. Defaults to '
                              u'current working directory.', default=os.getcwd())
+    parser.add_argument('--var-files', action='store',
+                        help=u'One or more YAML or JSON formatted files providing variables for '
+                             u'template expansion in container.yml.', default=None, nargs='*')
+
     subparsers = parser.add_subparsers(title='subcommand', dest='subcommand')
     for subcommand in AVAILABLE_COMMANDS:
         logger.debug('Registering subcommand %s', subcommand)

--- a/container/cli.py
+++ b/container/cli.py
@@ -172,9 +172,9 @@ def commandline():
     parser.add_argument('--project', '-p', action='store', dest='base_path',
                         help=u'Specify a path to your project. Defaults to '
                              u'current working directory.', default=os.getcwd())
-    parser.add_argument('--var-files', action='store',
-                        help=u'One or more YAML or JSON formatted files providing variables for '
-                             u'template expansion in container.yml.', default=None, nargs='*')
+    parser.add_argument('--var-file', action='store',
+                        help=u'Path to a YAML or JSON formatted file providing variables for '
+                             u'Jinja2 templating in container.yml.', default=None)
 
     subparsers = parser.add_subparsers(title='subcommand', dest='subcommand')
     for subcommand in AVAILABLE_COMMANDS:

--- a/container/config.py
+++ b/container/config.py
@@ -43,6 +43,9 @@ class AnsibleContainerConfig(Mapping):
         if template_vars:
             config = self._render_template(template_vars)
         for service, service_config in config['services'].items():
+            if not service_config or isinstance(service_config, basestring):
+                raise AnsibleContainerConfigException(u"Error: no definition found in container.yml for service %s."
+                                                      % service)
             if isinstance(service_config, dict):
                 dev_overrides = service_config.pop('dev_overrides', {})
                 if env == 'dev':

--- a/container/config.py
+++ b/container/config.py
@@ -6,8 +6,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 import os
+import json
 import yaml
+import re
 
+from jinja2 import Environment, FileSystemLoader
 from collections import Mapping
 from .exceptions import AnsibleContainerConfigException
 
@@ -17,34 +20,113 @@ class AnsibleContainerConfig(Mapping):
     _config = {}
     base_path = None
 
-    def __init__(self, base_path):
+    def __init__(self, base_path, var_files=None):
         self.base_path = base_path
+        self.var_files = var_files
         self.config_path = os.path.join(self.base_path, 'ansible/container.yml')
-        self.set_env('prod')
+        self._template_vars = None
+        self._config = self.set_env('prod')
 
     def set_env(self, env):
         assert env in ['dev', 'prod']
         config = self._read_config()
-        if not config.get('services'):
+        if not config.get('services') or isinstance(config.get('services'), basestring):
+            # Services must be defined, and not as a template variable
             raise AnsibleContainerConfigException("No services found in ansible/container.yml. "
                                                   "Have you defined any services?")
+        self._template_vars = self._get_variables(config)
+        if self._template_vars:
+            config = self._render_template()
+            logger.debug("Rendered config:")
+            logger.debug(config)
+            try:
+                config = yaml.safe_load(config)
+                if config.get('defaults'):
+                    del config['defaults']
+            except Exception as exc:
+                raise AnsibleContainerConfigException("Parsing container.yml - %s" % str(exc))
+
         for service, service_config in config['services'].items():
-            dev_overrides = service_config.pop('dev_overrides', {})
-            if env == 'dev':
-                service_config.update(dev_overrides)
-        self._config = config
+            if isinstance(service_config, dict):
+                dev_overrides = service_config.pop('dev_overrides', {})
+                if env == 'dev':
+                    service_config.update(dev_overrides)
+        return config
 
     def _read_config(self):
+        '''
+        Initial read of container.yml. Ensure all {{ vars }} are escaped with quotes, then parse yaml and
+        return the result. This allows us to extract 'defaults' before applying template vars.
+        '''
         try:
             ifs = open(self.config_path, 'r')
         except Exception:
             raise AnsibleContainerConfigException("Failed to open %s. Are you in the correct directory?" %
                                                   self.config_path)
         try:
-            config = yaml.safe_load(ifs)
+            config = ifs.read()
+            config = re.sub(r"}}(?!\"|\')", "}}'", re.sub(r"(?<!\"|\'){{", "'{{", config, flags=re.M), flags=re.M)
+            config = yaml.safe_load(config)
+            ifs.close()
+        except yaml.YAMLError as exc:
+            raise AnsibleContainerConfigException("Initial parse of container.yml - %s" % str(exc))
         except Exception as exc:
-            raise AnsibleContainerConfigException("Failed to parse container.yml - %s" % str(exc))
-        ifs.close()
+            raise AnsibleContainerConfigException("Reading container.yml - %s" % str(exc))
+        return config
+
+    def _render_template(self):
+        j2_tmpl_path = os.path.join(self.base_path, 'ansible')
+        j2_env = Environment(loader=FileSystemLoader(j2_tmpl_path))
+        j2_tmpl = j2_env.get_template('container.yml')
+        return j2_tmpl.render(**self._template_vars).encode('utf8')
+
+    def _get_variables(self, config):
+        new_vars = {}
+        if config.get('defaults'):
+            new_vars.update(config.pop('defaults'))
+        if self.var_files:
+            logger.debug('Reading variables from var files...')
+            for file in self.var_files:
+                new_vars.update(self._get_variables_from_file(file))
+        new_vars.update(self._get_environment_variables())
+        if new_vars:
+            logger.debug('Template variables: ')
+            logger.debug(json.dumps(new_vars, sort_keys=True, indent=4, separators=(',', ': ')))
+        return new_vars
+
+    def _get_environment_variables(self):
+        logger.debug('Getting AC environment variables...')
+        new_vars = {}
+        for var, value in os.environ.iteritems():
+            matches = re.match(r'^AC_(.+)$', var)
+            if matches:
+                new_vars[matches.group(1).lower()] = value
+        return new_vars
+
+    def _get_variables_from_file(self, file):
+        file_path = os.path.expandvars(os.path.expanduser(file))
+        if not os.path.isfile(file_path):
+            file_path = os.path.join(self.base_path, file)
+            if not os.path.isfile(file_path):
+                file_path = os.path.join(self.base_path, 'ansible', file)
+        if not os.path.isfile(file_path):
+            raise AnsibleContainerConfigException("Unable to locate %s. Check that the file exists and you"
+                                                  "have read access." % file_path)
+        try:
+            fs = open(file_path, 'r')
+            data = fs.read()
+            fs.close()
+        except Exception:
+            raise AnsibleContainerConfigException("Failed to open %s. Check that the file exists and you "
+                                                  "have read access." % file_path)
+        try:
+            config = json.loads(data)
+        except:
+            # Failed to load as JSON. Let's try YAML.
+            try:
+                config = yaml.safe_load(data)
+            except yaml.YAMLError as exc:
+                raise AnsibleContainerConfigException("Reading %s\n. YAML exception: %s" % (file_path, str(exc)))
         return config
 
     def __getitem__(self, item):

--- a/container/config.py
+++ b/container/config.py
@@ -20,82 +20,112 @@ class AnsibleContainerConfig(Mapping):
     _config = {}
     base_path = None
 
-    def __init__(self, base_path, var_files=None):
+    def __init__(self, base_path, var_file=None):
         self.base_path = base_path
-        self.var_files = var_files
+        self.var_file = var_file
         self.config_path = os.path.join(self.base_path, 'ansible/container.yml')
-        self._template_vars = None
-        self._config = self.set_env('prod')
+        self.set_env('prod')
 
     def set_env(self, env):
+        '''
+        Loads config from container.yml, resolves Jinja2 templates and stores the resulting dict to self._config.
+
+        :param env: string of either 'dev' or 'prod'. Indicates 'dev_overrides' handling.
+        :return: None
+        '''
         assert env in ['dev', 'prod']
         config = self._read_config()
         if not config.get('services') or isinstance(config.get('services'), basestring):
-            # Services must be defined, and not as a template variable
-            raise AnsibleContainerConfigException("No services found in ansible/container.yml. "
-                                                  "Have you defined any services?")
-        self._template_vars = self._get_variables(config)
-        if self._template_vars:
-            config = self._render_template()
-            logger.debug("Rendered config:")
-            logger.debug(config)
-            try:
-                config = yaml.safe_load(config)
-                if config.get('defaults'):
-                    del config['defaults']
-            except Exception as exc:
-                raise AnsibleContainerConfigException("Parsing container.yml - %s" % str(exc))
-
+            # Services must be defined, and not as a template variable.
+            raise AnsibleContainerConfigException(u"No services found in ansible/container.yml. "
+                                                  u"Have you defined any services?")
+        template_vars = self._get_variables(config)
+        if template_vars:
+            config = self._render_template(template_vars)
         for service, service_config in config['services'].items():
             if isinstance(service_config, dict):
                 dev_overrides = service_config.pop('dev_overrides', {})
                 if env == 'dev':
                     service_config.update(dev_overrides)
-        return config
+        logger.debug(u"Config:\n%s" % json.dumps(config,
+                                                 sort_keys=True,
+                                                 indent=4,
+                                                 separators=(',', ': ')))
+        self._config = config
 
     def _read_config(self):
         '''
-        Initial read of container.yml. Ensure all {{ vars }} are escaped with quotes, then parse yaml and
-        return the result. This allows us to extract 'defaults' before applying template vars.
+        Initial read of container.yml. Ensures all {{ vars }} are escaped with quotes, then parses the Yaml and
+        returns the resulting dict. Does not perform Jinja2 template rendering.
+
+        returns: dict
         '''
         try:
-            ifs = open(self.config_path, 'r')
-        except Exception:
-            raise AnsibleContainerConfigException("Failed to open %s. Are you in the correct directory?" %
+            with open(self.config_path, 'r') as f:
+                config = f.read()
+        except OSError:
+            raise AnsibleContainerConfigException(u"Failed to open %s. Are you in the correct directory?" %
                                                   self.config_path)
         try:
-            config = ifs.read()
-            config = re.sub(r"}}(?!\"|\')", "}}'", re.sub(r"(?<!\"|\'){{", "'{{", config, flags=re.M), flags=re.M)
+            # Escape vars. Replaces {{ with '{{ when not preceeded by a non-whitespace char and }} with  }}' when
+            # not followed by a non-whitespace char.
+            config = re.sub(r"}}(?!\S)", "}}'", re.sub(r"(?<!\S){{", "'{{", config))
             config = yaml.safe_load(config)
-            ifs.close()
         except yaml.YAMLError as exc:
-            raise AnsibleContainerConfigException("Initial parse of container.yml - %s" % str(exc))
-        except Exception as exc:
-            raise AnsibleContainerConfigException("Reading container.yml - %s" % str(exc))
+            raise AnsibleContainerConfigException(u"Initial parse of container.yml - %s" % str(exc))
+
         return config
 
-    def _render_template(self):
+    def _render_template(self, template_vars):
+        '''
+        Reads container.yml, applies Jinja2 template rendering, parses the Yaml and returns the resulting dict.
+
+        :param template_vars: dict providing context for Jinja2 template rendering
+        :return: dict
+        '''
         j2_tmpl_path = os.path.join(self.base_path, 'ansible')
         j2_env = Environment(loader=FileSystemLoader(j2_tmpl_path))
         j2_tmpl = j2_env.get_template('container.yml')
-        return j2_tmpl.render(**self._template_vars).encode('utf8')
+        config = j2_tmpl.render(**template_vars).encode('utf8')
+        logger.debug(u"Rendered config:\n %s" % config)
+        try:
+            config = yaml.safe_load(config)
+        except yaml.YAMLError as exc:
+            raise AnsibleContainerConfigException(u"Parsing container.yml - %s" % str(exc))
+        if config.get('defaults'):
+            del config['defaults']
+        return config
 
     def _get_variables(self, config):
+        '''
+        Resolve variables by creating an empty dict and updating it first with the 'defaults' section in the config,
+        then any variables from var_file, and finally any AC_* environment variables. Returns the resulting dict.
+
+        :param config: dict from parsed container.yml
+        :return: dict
+        '''
         new_vars = {}
         if config.get('defaults'):
             new_vars.update(config.pop('defaults'))
-        if self.var_files:
-            logger.debug('Reading variables from var files...')
-            for file in self.var_files:
-                new_vars.update(self._get_variables_from_file(file))
+        if self.var_file:
+            logger.debug('Reading variables from var file...')
+            new_vars.update(self._get_variables_from_file(self.var_file))
         new_vars.update(self._get_environment_variables())
-        if new_vars:
-            logger.debug('Template variables: ')
-            logger.debug(json.dumps(new_vars, sort_keys=True, indent=4, separators=(',', ': ')))
+        logger.debug(u'Template variables:\n %s' % json.dumps(new_vars,
+                                                              sort_keys=True,
+                                                              indent=4,
+                                                              separators=(',', ': ')))
         return new_vars
 
     def _get_environment_variables(self):
-        logger.debug('Getting AC environment variables...')
+        '''
+        Look for any environment variables that start with 'AC_'. Returns dict of key:value pairs, where the
+        key is the result of removing 'AC_' from the variable name and converting the remainder to lowercase.
+        For example, 'AC_DEBUG=1' becomes 'debug: 1'.
+
+        :return dict
+        '''
+        logger.debug(u'Getting environment variables...')
         new_vars = {}
         for var, value in os.environ.iteritems():
             matches = re.match(r'^AC_(.+)$', var)
@@ -104,29 +134,43 @@ class AnsibleContainerConfig(Mapping):
         return new_vars
 
     def _get_variables_from_file(self, file):
-        file_path = os.path.expandvars(os.path.expanduser(file))
-        if not os.path.isfile(file_path):
-            file_path = os.path.join(self.base_path, file)
+        '''
+        Read variables from a file. Checks if file contains an absolute path, if not then looks relative to base_path,
+        if still not found checks relative to base_path/ansible. If file extension is .yml | .yaml parses as Yaml,
+        otherwise attempts to parse as JSON. Returns file contents as dict.
+
+        :param file: string: Absolute file path or path relative to base_path or base_path/ansible.
+        :return: dict
+        '''
+        file_path = file
+        if not os.path.isfile(os.path.normpath(file_path)):
+            file_path = os.path.normpath(os.path.join(self.base_path, file))
             if not os.path.isfile(file_path):
-                file_path = os.path.join(self.base_path, 'ansible', file)
-        if not os.path.isfile(file_path):
-            raise AnsibleContainerConfigException("Unable to locate %s. Check that the file exists and you"
-                                                  "have read access." % file_path)
+                file_path = os.path.normpath(os.path.join(self.base_path, 'ansible', file))
+                if not os.path.isfile(file_path):
+                    raise AnsibleContainerConfigException(u"Unable to locate %s. Provide an absolute file path or "
+                                                          u"a path relative to %s or %s." %
+                                                          (file,
+                                                           os.path.normpath(self.base_path),
+                                                           os.path.normpath(os.path.join(self.base_path, 'ansible'))))
         try:
             fs = open(file_path, 'r')
             data = fs.read()
             fs.close()
-        except Exception:
-            raise AnsibleContainerConfigException("Failed to open %s. Check that the file exists and you "
-                                                  "have read access." % file_path)
-        try:
-            config = json.loads(data)
-        except:
-            # Failed to load as JSON. Let's try YAML.
+        except OSError as exc:
+            raise AnsibleContainerConfigException(u"Failed to open %s - %s" % (file_path, str(exc)))
+
+        if re.search(r'\.yml$|\.yaml$', file_path):
+            # file has '.yml' or '.yaml' extension
             try:
                 config = yaml.safe_load(data)
             except yaml.YAMLError as exc:
-                raise AnsibleContainerConfigException("Reading %s\n. YAML exception: %s" % (file_path, str(exc)))
+                raise AnsibleContainerConfigException(u"YAML exception: %s" %  str(exc))
+        else:
+            try:
+                config = json.loads(data)
+            except Exception as exc:
+                raise AnsibleContainerConfigException(u"JSON exception: %s" % str(exc))
         return config
 
     def __getitem__(self, item):

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -12,7 +12,6 @@ import getpass
 import json
 import base64
 import pprint
-import shutil
 
 import docker
 from docker.client import errors as docker_errors

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -210,7 +210,7 @@ class Engine(BaseEngine):
         :param namespace: path to append to the url. required if pull_from not provided.
         :return: config dict
         '''
-        config = get_config(self.base_path)
+        config = get_config(self.base_path, var_file=self.var_file)
         client = self.get_client()
 
         if pull_from:

--- a/container/engine.py
+++ b/container/engine.py
@@ -26,7 +26,7 @@ class BaseEngine(object):
     def __init__(self, base_path, project_name, params={}):
         self.base_path = base_path
         self.project_name = project_name
-        self.config = get_config(base_path)
+        self.config = get_config(base_path, var_files=params.get('var_files'))
         logger.debug('Initialized with params: %s', params)
         self.params = params
 

--- a/container/engine.py
+++ b/container/engine.py
@@ -26,14 +26,15 @@ class BaseEngine(object):
     def __init__(self, base_path, project_name, params={}):
         self.base_path = base_path
         self.project_name = project_name
-        self.config = get_config(base_path, var_files=params.get('var_files'))
-        logger.debug('Initialized with params: %s', params)
+        self.var_file = params.get('var_file')
+        self.config = get_config(base_path, var_file=self.var_file)
         self.params = params
-
         self.support_init = True
         self.supports_build = True
         self.supports_push = True
         self.supports_run = True
+
+        logger.debug('Initialized with params: %s', params)
 
 
     def all_hosts_in_orchestration(self):

--- a/container/templates/ansible-container-inventory.py
+++ b/container/templates/ansible-container-inventory.py
@@ -7,10 +7,17 @@ import argparse
 import re
 
 def config_keys():
-    ifs = open('/ansible-container/ansible/container.yml', 'r')
-    config = ifs.read()
-    config = re.sub(r"}}(?!\"|\')", "}}'", re.sub(r"(?<!\"|\'){{", "'{{", config, flags=re.M), flags=re.M)
-    config = yaml.safe_load(config)
+    '''
+    Read container.yml and return the set of service keys.
+
+    :return: list
+    '''
+    with open('/ansible-container/ansible/container.yml', 'r') as f:
+        config = f.read()
+        # Escape any vars. Replaces {{ with '{{ when not preceded by a non-whitespace
+        # char and }} with  }}' when not followed by a non-whitespace char.
+        config = re.sub(r"}}(?!\S)", "}}'", re.sub(r"(?<!\S){{", "'{{", config))
+        config = yaml.safe_load(config)
     return config['services'].keys()
 
 def cmd_list():

--- a/container/templates/ansible-container-inventory.py
+++ b/container/templates/ansible-container-inventory.py
@@ -4,10 +4,13 @@ import yaml
 import json
 import sys
 import argparse
+import re
 
 def config_keys():
     ifs = open('/ansible-container/ansible/container.yml', 'r')
-    config = yaml.safe_load(ifs)
+    config = ifs.read()
+    config = re.sub(r"}}(?!\"|\')", "}}'", re.sub(r"(?<!\"|\'){{", "'{{", config, flags=re.M), flags=re.M)
+    config = yaml.safe_load(config)
     return config['services'].keys()
 
 def cmd_list():

--- a/container/utils.py
+++ b/container/utils.py
@@ -72,8 +72,8 @@ def jinja_render_to_temp(template_file, temp_dir, dest_file, **context):
     open(os.path.join(temp_dir, dest_file), 'w').write(
         rendered.encode('utf8'))
 
-def get_config(base_path):
-    return AnsibleContainerConfig(base_path)
+def get_config(base_path, var_files=None):
+    return AnsibleContainerConfig(base_path, var_files=var_files)
 
 def config_format_version(base_path, config_data=None):
     if not config_data:

--- a/container/utils.py
+++ b/container/utils.py
@@ -72,8 +72,8 @@ def jinja_render_to_temp(template_file, temp_dir, dest_file, **context):
     open(os.path.join(temp_dir, dest_file), 'w').write(
         rendered.encode('utf8'))
 
-def get_config(base_path, var_files=None):
-    return AnsibleContainerConfig(base_path, var_files=var_files)
+def get_config(base_path, var_file=None):
+    return AnsibleContainerConfig(base_path, var_file=var_file)
 
 def config_format_version(base_path, config_data=None):
     if not config_data:

--- a/test/integration/projects/vartest/ansible/container.yml
+++ b/test/integration/projects/vartest/ansible/container.yml
@@ -1,0 +1,14 @@
+version: "1"
+services:
+
+   web:
+     image: {{ web_image }}
+     ports: {{ web_ports }}
+     command: ['sleep', '10']
+     dev_overrides:
+       environment:
+         - DEBUG={{ debug }}
+
+   db: {{ db_service }}
+
+registries: {}

--- a/test/integration/projects/vartest/ansible/devel.txt
+++ b/test/integration/projects/vartest/ansible/devel.txt
@@ -1,0 +1,16 @@
+
+{
+  "debug": 1,
+  "web_ports": ["8000:8000"],
+  "web_image: "python:2.7",
+  "db_service": {
+    "image": "python:2.7",
+    "command": "sleep 10",
+    "expose": [5432]
+    "environment": {
+         "POSTGRES_DB_NAME": "foobar",
+         "POSTGRES_USER": "admin",
+         "POSTGRES_PASSWORD": "admin"
+    }
+  } 
+}

--- a/test/integration/projects/vartest/ansible/devel.yaml
+++ b/test/integration/projects/vartest/ansible/devel.yaml
@@ -1,0 +1,14 @@
+---
+debug: 1 
+web_ports:
+  - 8000:8000
+web_image: "python:2.7"
+db_service: 
+  image: "python:2.7" 
+  command: sleep 10
+  expose:
+    - 5432
+  environment:
+    POSTGRES_DB_NAME: foobar
+    POSTGRES_USER: admin
+    POSTGRES_PASSWORD: admin

--- a/test/integration/projects/vartest/ansible/devel.yaml
+++ b/test/integration/projects/vartest/ansible/devel.yaml
@@ -9,6 +9,6 @@ db_service:
   expose:
     - 5432
   environment:
-    POSTGRES_DB_NAME: foobar
-    POSTGRES_USER: admin
-    POSTGRES_PASSWORD: admin
+    - POSTGRES_DB_NAME=foobar
+    - POSTGRES_USER-admin
+    - POSTGRES_PASSWORD=admin

--- a/test/integration/projects/vartest/ansible/main.yml
+++ b/test/integration/projects/vartest/ansible/main.yml
@@ -1,0 +1,10 @@
+# main.yml
+#
+---
+- name: Fake play
+  gather_facts: no
+  hosts: all 
+  tasks:
+    - name: Say hello
+      shell: echo "Hello world!"
+

--- a/test/integration/projects/vartest/ansible/requirements.txt
+++ b/test/integration/projects/vartest/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.8.0

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -111,14 +111,14 @@ def test_restart_service_minimal_docker_container():
 
 def test_build_with_var_file():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', '--var-files=devel.yaml','--debug', 'build', '--local-build',
+    result = env.run('ansible-container', '--var-file=devel.yaml','--debug', 'build', '--local-build',
                      cwd=project_dir('vartest'), expect_stderr=True)
     assert "ansible_ansible-container_1 exited with code 0" in result.stderr
     assert "Exporting built containers as images..." in result.stderr
 
 def test_run_with_var_file():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', '--var-files=devel.yaml', '--debug', 'run',
+    result = env.run('ansible-container', '--var-file=devel.yaml', '--debug', 'run',
                      cwd=project_dir('vartest'), expect_stderr=True)
     assert "ansible_db_1 exited with code 0" in result.stdout
     assert "ansible_web_1 exited with code 0" in result.stdout

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -109,6 +109,20 @@ def test_restart_service_minimal_docker_container():
     assert "Restarting ansible_minimal2_1 ... done" not in result.stderr
 
 
+def test_build_with_var_file():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', '--var-files=devel.yaml','--debug', 'build', '--local-build',
+                     cwd=project_dir('vartest'), expect_stderr=True)
+    assert "ansible_ansible-container_1 exited with code 0" in result.stderr
+    assert "Exporting built containers as images..." in result.stderr
+
+def test_run_with_var_file():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', '--var-files=devel.yaml', '--debug', 'run',
+                     cwd=project_dir('vartest'), expect_stderr=True)
+    assert "ansible_db_1 exited with code 0" in result.stdout
+    assert "ansible_web_1 exited with code 0" in result.stdout
+
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()
 #    result = env.run('ansible-container', 'shipit', 'kube', cwd=project_dir('minimal'), expect_error=True)

--- a/test/run.sh
+++ b/test/run.sh
@@ -11,7 +11,7 @@ export ANSIBLE_CONTAINER_PATH=${source_root}
 
 image_exists=$(docker images local-test:latest | wc -l)
 if [ "${image_exists}" -le "1" ]; then
-   ansible-container --project "${source_root}/test/local" build --flatten --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
+   ansible-container --project "${source_root}/test/local" build --local-build --flatten --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
 fi
 
 ansible-container --project "${source_root}/test/local" run

--- a/test/unit/container/test_config.py
+++ b/test/unit/container/test_config.py
@@ -4,6 +4,7 @@ from os import path
 import unittest
 import os
 import yaml
+import json
 
 from container.config import AnsibleContainerConfig
 from container.exceptions import AnsibleContainerConfigException
@@ -21,19 +22,49 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp()
         self.ansible_dir = path.join(self.test_dir, "ansible")
         os.mkdir(self.ansible_dir)
-        # Create container.yml
-        fs = open(os.path.join(self.ansible_dir,'container.yml'), 'w')
-        fs.write('version: "1"\nservices:\n  web:\n    image: {{ web_image }}\n'
-                 '    ports: {{ web_ports }}\n    command: ["sleep", "1d"]\n'
-                 '    dev_overrides:\n      environment:\n        - DEBUG={{ debug }}\n'
-                 '  db: {{ db_service }}\nregistries: {}\n')
-        fs.close()
+        # Create container.yml.
+        container_text = (
+            "version: '1'\n"
+            "defaults:\n"
+            "    web_image: apache:latest\n"
+            "    web_ports: ['8080:80']\n"
+            "    debug: 0\n"
+            "    foo: bar\n"
+            "services:\n"
+            "    web:\n"
+            "        image: {{ web_image }}\n"
+            "        ports: {{ web_ports }}\n"
+            "        command: ['sleep', '1d']\n"
+            "        foo: {{ foo }}\n"
+            "        dev_overrides:\n"
+            "            environment: ['DEBUG={{ debug }}']\n"
+            "    db: {{ db_service }}\n"
+            "registries: {}\n"
+        )
+        with open(os.path.join(self.ansible_dir, 'container.yml'), 'w') as fs:
+            fs.write(container_text)
+        var_data = {
+            "debug": 1,
+            "web_ports": ["8000:8000"],
+            "web_image": "python:2.7",
+            "foo": "baz",
+            "db_service": {
+                "image": "python:2.7",
+                "command": "sleep 10",
+                "expose": [5432],
+                "environment": {
+                    "POSTGRES_DB_NAME": "foobar",
+                    "POSTGRES_USER": "admin",
+                    "POSTGRES_PASSWORD": "admin"
+                }
+            }
+        }
         # Create var file devel.yml
-        fs = open(os.path.join(self.ansible_dir,'devel.yml'), 'w')
-        fs.write('debug: 1\nweb_ports:\n  - 8000:8000\nweb_image: "busybox:latest"\ndb_service:\n'
-                 '  image: postgres:9.5.4\n  expose:\n    - 5432\n  environment:\n    POSTGRES_DB_NAME: foobar\n'
-                 '    POSTGRES_USER: admin\n    POSTGRES_PASSWORD: admin\n')
-        fs.close()
+        with open(os.path.join(self.ansible_dir, 'devel.yml'), 'w') as fs:
+            yaml.safe_dump(var_data, fs, default_flow_style=False, indent=2)
+        # create var file devel.txt
+        with open(os.path.join(self.ansible_dir, 'devel.txt'), 'w') as fs:
+            fs.write(json.dumps(var_data))
         self.config = AnsibleContainerConfig(self.test_dir)
 
     def tearDown(self):
@@ -43,16 +74,34 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.assertEqual(len(self.config._config['services'].keys()), 2, 'Failed to load container.yml')
 
     def test_should_quote_template_vars(self):
-        self.assertTrue(isinstance(self.config._config['services']['web']['image'], basestring),
+        config = self.config._read_config()
+        self.assertTrue(isinstance(config['services']['web']['image'], basestring),
                         'Failed to escape web.image.')
-        self.assertTrue(isinstance(self.config._config['services']['web']['ports'], basestring),
+        self.assertTrue(isinstance(config['services']['web']['ports'], basestring),
                         'Failed to escape web.ports.')
-        self.assertTrue(isinstance(self.config._config['services']['db'], basestring),
+        self.assertTrue(isinstance(config['services']['db'], basestring),
                         'Failed to escape db service.')
 
-    def test_should_read_var_file(self):
+    def test_should_remove_defaults_section(self):
+        self.assertEqual(self.config._config.get('defaults', None), None, 'Failed to remove defaults.')
+
+    def test_should_parse_defaults(self):
+        self.config.var_file = None
+        config = self.config._read_config()
+        template_vars = self.config._get_variables(config)
+        self.assertEqual(template_vars['web_image'], 'apache:latest')
+        self.assertEqual(template_vars['debug'], 0)
+        self.assertEqual(template_vars['foo'], 'bar')
+
+    def test_should_parse_yaml_file(self):
         new_vars = self.config._get_variables_from_file('devel.yml')
-        self.assertEqual(new_vars['debug'], 1, 'Failed to read and parse devel.yml')
+        self.assertEqual(new_vars['debug'], 1, 'Failed to parse devel.yml - checked debug')
+        self.assertEqual(new_vars['web_image'], "python:2.7", "Failed to parse devel.yml - web_image")
+
+    def test_should_parse_json_file(self):
+        new_vars = self.config._get_variables_from_file('devel.txt')
+        self.assertEqual(new_vars['debug'], 1, 'Failed to parse devel.txt - checked debug')
+        self.assertEqual(new_vars['web_image'], "python:2.7", "Failed to parse devel.txt - web_image")
 
     def test_should_raise_file_not_found_error(self):
         with self.assertRaises(AnsibleContainerConfigException) as exc:
@@ -60,19 +109,31 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.assertIn('Unable to locate', exc.exception.args[0])
 
     def test_should_read_environment_vars(self):
-        os.environ.update({u'AC_DEBUG': '1'})
+        os.environ.update({u'AC_DEBUG': '2'})
         new_vars = self.config._get_environment_variables()
-        self.assertDictContainsSubset({u'debug': '1'}, new_vars)
+        self.assertDictContainsSubset({u'debug': '2'}, new_vars)
 
-    def test_should_get_defaults(self):
-        # Create container.yml with defaults
-        fs = open(os.path.join(self.ansible_dir, 'container.yml'), 'w')
-        fs.write('version: "1"\ndefaults:\n  foo: bar\n  things:\n    - one\n    - two\n'
-                 'services:\n  web:\n    image: {{ web_image }}\n'
-                 '    ports: {{ web_ports }}\n    command: ["sleep", "1d"]\n'
-                 '    dev_overrides:\n      environment:\n        - DEBUG={{ debug }}\n'
-                 '  db: {{ db_service }}\nregistries: {}\n')
-        fs.close()
-        config = AnsibleContainerConfig(self.test_dir, ['devel.yml'])
-        self.assertEqual(config._config.get('defaults', None), None, 'Failed to remove defaults.')
-        self.assertDictContainsSubset({u'foo': 'bar'}, config._template_vars)
+    def test_should_give_precedence_to_env_vars(self):
+        # If an environment var exists, it should get precedence.
+        os.environ.update({u'AC_FOO': 'cats'})
+        self.config.var_file = 'devel.yml'
+        self.config.set_env('prod')
+        self.assertEqual(self.config._config['services']['web']['foo'], 'cats')
+
+    def test_should_give_precedence_to_file_vars(self):
+        # If no environment var, then var defined in var_file should get precedence.
+        if os.environ.get('AC_FOO'):
+            del os.environ['AC_FOO']
+        self.config.var_file = 'devel.yml'
+        self.config.set_env('prod')
+        self.assertEqual(self.config._config['services']['web']['foo'], 'baz')
+
+    def test_should_give_precedence_to_default_vars(self):
+        # If no environment var and no var_file, then the default value should be used.
+        if os.environ.get('AC_FOO'):
+            del os.environ['AC_FOO']
+        self.config.var_file = None
+        self.config.set_env('prod')
+        self.assertEqual(self.config._config['services']['web']['foo'], 'bar')
+
+

--- a/test/unit/container/test_config.py
+++ b/test/unit/container/test_config.py
@@ -24,38 +24,40 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         os.mkdir(self.ansible_dir)
         # Create container.yml.
         container_text = (
-            "version: '1'\n"
-            "defaults:\n"
-            "    web_image: apache:latest\n"
-            "    web_ports: ['8080:80']\n"
-            "    debug: 0\n"
-            "    foo: bar\n"
-            "services:\n"
-            "    web:\n"
-            "        image: {{ web_image }}\n"
-            "        ports: {{ web_ports }}\n"
-            "        command: ['sleep', '1d']\n"
-            "        foo: {{ foo }}\n"
-            "        dev_overrides:\n"
-            "            environment: ['DEBUG={{ debug }}']\n"
-            "    db: {{ db_service }}\n"
-            "registries: {}\n"
+            u"version: '1'\n"
+            u"defaults:\n"
+            u"    web_image: apache:latest\n"
+            u"    web_ports: ['8080:80']\n"
+            u"    debug: 0\n"
+            u"    foo: bar\n"
+            u"    db_service:\n"
+            u"      image: 'postgres:9.5.4'\n"
+            u"services:\n"
+            u"    web:\n"
+            u"        image: {{ web_image }}\n"
+            u"        ports: {{ web_ports }}\n"
+            u"        command: ['sleep', '1d']\n"
+            u"        foo: {{ foo }}\n"
+            u"        dev_overrides:\n"
+            u"            environment: ['DEBUG={{ debug }}']\n"
+            u"    db: {{ db_service }}\n"
+            u"registries: {}\n"
         )
         with open(os.path.join(self.ansible_dir, 'container.yml'), 'w') as fs:
             fs.write(container_text)
         var_data = {
-            "debug": 1,
-            "web_ports": ["8000:8000"],
-            "web_image": "python:2.7",
-            "foo": "baz",
-            "db_service": {
-                "image": "python:2.7",
-                "command": "sleep 10",
-                "expose": [5432],
-                "environment": {
-                    "POSTGRES_DB_NAME": "foobar",
-                    "POSTGRES_USER": "admin",
-                    "POSTGRES_PASSWORD": "admin"
+            u"debug": 1,
+            u"web_ports": [u"8000:8000"],
+            u"web_image": u"python:2.7",
+            u"foo": u"baz",
+            u"db_service": {
+                u"image": u"python:2.7",
+                u"command": u"sleep 10",
+                u"expose": [5432],
+                u"environment": {
+                    u"POSTGRES_DB_NAME": u"foobar",
+                    u"POSTGRES_USER": u"admin",
+                    u"POSTGRES_PASSWORD": u"admin"
                 }
             }
         }

--- a/test/unit/container/test_config.py
+++ b/test/unit/container/test_config.py
@@ -1,0 +1,78 @@
+import shutil
+import tempfile
+from os import path
+import unittest
+import os
+import yaml
+
+from container.config import AnsibleContainerConfig
+from container.exceptions import AnsibleContainerConfigException
+
+
+class TestAnsibleContainerConfig(unittest.TestCase):
+
+    '''
+    This test class creates a temporary folder with only "main.yml"
+    written out. This tests passses if AnsibleContainerNotInitializedException
+    is correctly raised due to a missing 'container.yml' file.
+    '''
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.ansible_dir = path.join(self.test_dir, "ansible")
+        os.mkdir(self.ansible_dir)
+        # Create container.yml
+        fs = open(os.path.join(self.ansible_dir,'container.yml'), 'w')
+        fs.write('version: "1"\nservices:\n  web:\n    image: {{ web_image }}\n'
+                 '    ports: {{ web_ports }}\n    command: ["sleep", "1d"]\n'
+                 '    dev_overrides:\n      environment:\n        - DEBUG={{ debug }}\n'
+                 '  db: {{ db_service }}\nregistries: {}\n')
+        fs.close()
+        # Create var file devel.yml
+        fs = open(os.path.join(self.ansible_dir,'devel.yml'), 'w')
+        fs.write('debug: 1\nweb_ports:\n  - 8000:8000\nweb_image: "busybox:latest"\ndb_service:\n'
+                 '  image: postgres:9.5.4\n  expose:\n    - 5432\n  environment:\n    POSTGRES_DB_NAME: foobar\n'
+                 '    POSTGRES_USER: admin\n    POSTGRES_PASSWORD: admin\n')
+        fs.close()
+        self.config = AnsibleContainerConfig(self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_should_instantiate(self):
+        self.assertEqual(len(self.config._config['services'].keys()), 2, 'Failed to load container.yml')
+
+    def test_should_quote_template_vars(self):
+        self.assertTrue(isinstance(self.config._config['services']['web']['image'], basestring),
+                        'Failed to escape web.image.')
+        self.assertTrue(isinstance(self.config._config['services']['web']['ports'], basestring),
+                        'Failed to escape web.ports.')
+        self.assertTrue(isinstance(self.config._config['services']['db'], basestring),
+                        'Failed to escape db service.')
+
+    def test_should_read_var_file(self):
+        new_vars = self.config._get_variables_from_file('devel.yml')
+        self.assertEqual(new_vars['debug'], 1, 'Failed to read and parse devel.yml')
+
+    def test_should_raise_file_not_found_error(self):
+        with self.assertRaises(AnsibleContainerConfigException) as exc:
+            self.config._get_variables_from_file('foo')
+        self.assertIn('Unable to locate', exc.exception.args[0])
+
+    def test_should_read_environment_vars(self):
+        os.environ.update({u'AC_DEBUG': '1'})
+        new_vars = self.config._get_environment_variables()
+        self.assertDictContainsSubset({u'debug': '1'}, new_vars)
+
+    def test_should_get_defaults(self):
+        # Create container.yml with defaults
+        fs = open(os.path.join(self.ansible_dir, 'container.yml'), 'w')
+        fs.write('version: "1"\ndefaults:\n  foo: bar\n  things:\n    - one\n    - two\n'
+                 'services:\n  web:\n    image: {{ web_image }}\n'
+                 '    ports: {{ web_ports }}\n    command: ["sleep", "1d"]\n'
+                 '    dev_overrides:\n      environment:\n        - DEBUG={{ debug }}\n'
+                 '  db: {{ db_service }}\nregistries: {}\n')
+        fs.close()
+        config = AnsibleContainerConfig(self.test_dir, ['devel.yml'])
+        self.assertEqual(config._config.get('defaults', None), None, 'Failed to remove defaults.')
+        self.assertDictContainsSubset({u'foo': 'bar'}, config._template_vars)


### PR DESCRIPTION
##### ISSUE TYPE
Feature Pull Request
 
##### SUMMARY
Per issue #120 adds support for jinja2 style variables in container.yml.

Modifies AnsibleContainerConfig to support Jinja2 template rendering. AnsibleContainerConfig resolves variable values and performs the expansion on initialization. It uses the following order of precedence when resolving variables: 

- environment vars (any environment vars starting with AC)
- variables provided in a file using new *--var-file* option
- and finally a new 'defaults' section added to the top level of container.yml.

For example, given the following:

- environment var AC_DEBUG=1
- devel.yml as a var file that defines debug=0
- defaults section in container.yml defining debug: 2

The environment variable would win, giving *debug* a value of 1.

Here is an example container.yml taken from the new test project:

```
version: "1"
services:
   web:
     image: {{ web_image }}
     ports: {{ web_ports }}
     command: ['sleep', '10']
     dev_overrides:
       environment:
         - DEBUG={{ debug }}

   db: {{ db_service }}

registries: {}
```
Variables can be raw as above or enclosed in quotes. If enclosed in quotes, the result after template expansion will remain enclosed in quotes. Primitives and complex data structures can be substituted. 

Here's the var file used in the test:

```
---
debug: 1
web_ports:
  - 8000:8000
web_image: "python:2.7"
db_service:
  image: "python:2.7"
  command: sleep 10
  expose:
    - 5432
  environment:
    POSTGRES_DB_NAME: foobar
    POSTGRES_USER: admin
    POSTGRES_PASSWORD: admin
```
To build the project:

```
ansible-container --var-file devel.yaml build --local-build
```

To run the project

```
ansible-container --var-file devel.yaml run
```

To push the project:

```
ansible-container --var-file devel.yaml push
```

To ship the project:

```
ansible-container --var-file devel.yaml shipit
```

If using variables in container.yml, a mechanism for resolving variable values must be supplied with each command, as each command attempts to access container.yml. The mechanism can be --var-file (as above), or it can be the defaults section in the container.yml, environment vars, or a combination of all of the above. In other words, users will not necessarily always have to provide --var-file.

Template expansion occurs prior to the start of the build. It occurs just before the initial containers are created for each service. The containers are instantiated. The build process then runs the playbook, which does not rely on knowing the configuration of each service. It only requires service names. Any post build steps happen on the host where template expansion has already occurred. 

All that being said, the inventory script was updated. The update entails escaping any raw variables to allow them to pass PyYaml parsing. To work around this for testing I employed the --local-build option, which enables using the modified script. Once this PR is merged we will need to update the build image on Docker Hub.

This PR includes unit and integration tests. So there is at least an example, however it does not include documentation. After this is merged, I will take the responsibility of immediately updating docs and creating an example (outside of the new test project) using variable. The docs will be added as part of resolving #108 *Reference for containery.yml*, which is assigned to me. 