### PR TITLE
Remove --local-builder from test runner. The new ansible-builder-cont…

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -11,7 +11,7 @@ export ANSIBLE_CONTAINER_PATH=${source_root}
 
 image_exists=$(docker images local-test:latest | wc -l)
 if [ "${image_exists}" -le "1" ]; then
-   ansible-container --project "${source_root}/test/local" build --local-build --flatten --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
+   ansible-container --project "${source_root}/test/local" build --flatten --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
 fi
 
 ansible-container --project "${source_root}/test/local" run


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### SUMMARY

New ansible-container-builder image with updated inventory script now available on Docker Hub. Should no longer need --local-builder flag.