### PR TITLE
Correctly format list of volumes for `build` command

### DIFF
--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -14,6 +14,7 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/tmp/docker.sock:Z{% endif %}
-    {% if with_volumes %}{% for vol in with_volumes %}- {{ vol }}{% endfor %}{% endif %}
+    {% if with_volumes %}{% for vol in with_volumes %}
+    - {{ vol }}{% endfor %}{% endif %}
   working_dir: /ansible-container/ansible/
 {{ config }}


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### SUMMARY
Fixes #126. List of volumes from --with-volumes was not rendered correctly in the docker-compose template used by the build command.