### PR TITLE
Feature/fix templating

### DIFF
--- a/container/templates/ansible-container-inventory.py
+++ b/container/templates/ansible-container-inventory.py
@@ -5,20 +5,17 @@ import json
 import sys
 import argparse
 import re
+import os
+
 
 def config_keys():
     '''
-    Read container.yml and return the set of service keys.
+    Get the list of hosts from env var ANSIBLE_ORCHESTRATED_HOSTS.
 
     :return: list
     '''
-    with open('/ansible-container/ansible/container.yml', 'r') as f:
-        config = f.read()
-        # Escape any vars. Replaces {{ with '{{ when not preceded by a non-whitespace
-        # char and }} with  }}' when not followed by a non-whitespace char.
-        config = re.sub(r"}}(?!\S)", "}}'", re.sub(r"(?<!\S){{", "'{{", config))
-        config = yaml.safe_load(config)
-    return config['services'].keys()
+    return os.environ.get('ANSIBLE_ORCHESTRATED_HOSTS', '').split(',')
+
 
 def cmd_list():
     hosts = config_keys()
@@ -31,6 +28,7 @@ def cmd_list():
             }
         )
     )
+
 
 def cmd_host(host):
     hosts = config_keys()

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -9,6 +9,7 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- DOCKER_CERT_PATH=/docker-certs/{% endif %}
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
+    - ANSIBLE_ORCHESTRATED_HOSTS={% for host in hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
     {% if with_variables %}{% for env_var in with_variables %}
     - {{ env_var }}
     {% endfor %}{% endif %}

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -9,6 +9,7 @@ ansible-container:
     {% if env.DOCKER_CERT_PATH %}- DOCKER_CERT_PATH=/docker-certs/{% endif %}
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
+    - ANSIBLE_ORCHESTRATED_HOSTS={% for host in hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
   volumes:
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/var/run/docker.sock{% endif %}
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}

--- a/test/unit/container/test_config.py
+++ b/test/unit/container/test_config.py
@@ -75,25 +75,14 @@ class TestAnsibleContainerConfig(unittest.TestCase):
     def test_should_instantiate(self):
         self.assertEqual(len(self.config._config['services'].keys()), 2, 'Failed to load container.yml')
 
-    def test_should_quote_template_vars(self):
-        config = self.config._read_config()
-        self.assertTrue(isinstance(config['services']['web']['image'], basestring),
-                        'Failed to escape web.image.')
-        self.assertTrue(isinstance(config['services']['web']['ports'], basestring),
-                        'Failed to escape web.ports.')
-        self.assertTrue(isinstance(config['services']['db'], basestring),
-                        'Failed to escape db service.')
-
     def test_should_remove_defaults_section(self):
         self.assertEqual(self.config._config.get('defaults', None), None, 'Failed to remove defaults.')
 
     def test_should_parse_defaults(self):
-        self.config.var_file = None
-        config = self.config._read_config()
-        template_vars = self.config._get_variables(config)
-        self.assertEqual(template_vars['web_image'], 'apache:latest')
-        self.assertEqual(template_vars['debug'], 0)
-        self.assertEqual(template_vars['foo'], 'bar')
+        defaults = self.config._get_defaults()
+        self.assertEqual(defaults['foo'], 'bar')
+        self.assertEqual(defaults['debug'], 0)
+        self.assertEqual(defaults['web_image'], 'apache:latest')
 
     def test_should_parse_yaml_file(self):
         new_vars = self.config._get_variables_from_file('devel.yml')


### PR DESCRIPTION
##### ISSUE TYPE
 Bugfix Pull Request
 
##### SUMMARY
Fixes #205.

Refactored config.py:
- Remove attempts to escape Jinja expressions. The regex was not taking into account all of the possible Jinja delimiters, and it did not account for control blocks.
- Now anything in container.yml can be templated.

Changed the inventory script:
- Completely removed the read of container.yml.
- The inventory script needs a list of hosts corresponding to the list of orchestrated containers, and we now pass that list via environment variable.
