### PR TITLE
Bump Ansible version to 2.1.1.0

### DIFF
--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -11,5 +11,5 @@ RUN apt-get update -y && \
 
 ADD builder.sh /usr/local/bin/builder.sh
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
-RUN pip install -q --no-cache-dir ansible==2.1.0.0 PyYAML==3.11
+RUN pip install -q --no-cache-dir ansible==2.1.1.0 PyYAML==3.11
 


### PR DESCRIPTION
##### ISSUE TYPE
 Bugfix Pull Request
 
##### SUMMARY
Fix #208 

This is a follow up to the fix for #208. Updated the Ansible version to 2.1.1.0 in the Ansible Container Builder image, but did not update the Dockerfile template used by the `--local-build` option on the `build` command. This PR contains the update.