### PR TITLE
Make existing Ansible content usable by adding --playbook option and …

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -147,10 +147,6 @@ def subcmd_shipit_parser(parser, subparser):
 
 def commandline():
 
-    # default_base_path = os.getcwd()
-    # if os.environ.get('ANSIBLE_CONTAINER_PROJECT'):
-    #     default_base_path = os.environ['ANSIBLE_CONTAINER_PROJECT']
-
     parser = argparse.ArgumentParser(description=u'Build, orchestrate, run, and '
                                                  u'ship Docker containers with '
                                                  u'Ansible playbooks')
@@ -166,8 +162,8 @@ def commandline():
                         help=u'Path to a YAML or JSON formatted file providing variables for '
                              u'Jinja2 templating in container.yml.', default=None)
     parser.add_argument('--playbook', action='store',
-                        help=u'Path to a playbook, overriding main.yml. Must be a valid path inside '
-                             u'Ansible Builder Container.', dest='playbook', default=None)
+                        help=u'Path to a playbook, overriding main.yml. Path will become a volume '
+                             u'in Ansible Builder Container', dest='playbook', default='main.yml')
     parser.add_argument('--with-volumes', '-v', action='append',
                         help=u'Mount one or more volumes to the Ansible Builder Container. '
                              u'Specify volumes as strings using the Docker volume format.', default=[])

--- a/container/config.py
+++ b/container/config.py
@@ -31,7 +31,7 @@ class AnsibleContainerConfig(Mapping):
         self.config_path = os.path.join(self.base_path, 'ansible/container.yml')
         self.all_filters = self.filter_loader.all()
         self.set_env('prod')
-
+    
     def set_env(self, env):
         '''
         Loads config from container.yml, performs Jinja templating, and stores the resulting dict to self._config.
@@ -48,7 +48,6 @@ class AnsibleContainerConfig(Mapping):
             raise AnsibleContainerConfigException(u"Parsing container.yml - %s" % str(exc))
         if config.get('defaults'):
             del config['defaults']
-
         for service, service_config in config['services'].items():
             if not service_config or isinstance(service_config, basestring):
                 raise AnsibleContainerConfigException(u"Error: no definition found in container.yml for service %s."

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -85,7 +85,7 @@ class Engine(BaseEngine):
 
         :return: generator of strings
         """
-        assert_initialized(self.base_path)
+        assert_initialized(self.base_path, playbook=self.playbook)
         client = self.get_client()
         with make_temp_dir() as temp_dir:
             logger.info('Building Docker Engine context...')
@@ -757,6 +757,13 @@ class Engine(BaseEngine):
         config_yaml = yaml_dump(config)
         logger.debug('Config YAML is')
         logger.debug(config_yaml)
+        with_volumes = self.params.get('with_volumes')
+        with_variables = self.params.get('with_variables')
+
+        logger.debug("with_volumes: %s" % with_volumes)
+
+        #logger.debug("with volumes: {0}\n with_variables: {1}".format(','.join(with_volumes),
+        #                                                              ','.join(with_variables)))
         jinja_render_to_temp('%s-docker-compose.j2.yml' % (operation,),
                              temp_dir,
                              'docker-compose.yml',
@@ -768,6 +775,9 @@ class Engine(BaseEngine):
                              builder_img_id=builder_img_id,
                              config=config_yaml,
                              env=os.environ,
+                             playbook=self.playbook,
+                             with_volumes=with_volumes,
+                             with_variables=with_variables,
                              **context)
         options = self.DEFAULT_COMPOSE_OPTIONS.copy()
 

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -759,11 +759,8 @@ class Engine(BaseEngine):
         logger.debug(config_yaml)
         with_volumes = self.params.get('with_volumes')
         with_variables = self.params.get('with_variables')
-
-        logger.debug("with_volumes: %s" % with_volumes)
-
-        #logger.debug("with volumes: {0}\n with_variables: {1}".format(','.join(with_volumes),
-        #                                                              ','.join(with_variables)))
+        logger.debug("with volumes: {0}\n with_variables: {1}".format(','.join(with_volumes),
+                                                                      ','.join(with_variables)))
         jinja_render_to_temp('%s-docker-compose.j2.yml' % (operation,),
                              temp_dir,
                              'docker-compose.yml',

--- a/container/docker/utils.py
+++ b/container/docker/utils.py
@@ -82,6 +82,7 @@ def config_to_compose(config):
     # removing the ones that aren't.
     compose = copy.deepcopy(config.get('services', {}))
     assert compose is not config.get('services')
+    compose.pop('ansible_build')
     for service, service_config in compose.items():
         if 'options' in service_config:
             del service_config['options']

--- a/container/exceptions.py
+++ b/container/exceptions.py
@@ -8,7 +8,6 @@ logger = logging.getLogger(__name__)
 class AnsibleContainerNotInitializedException(Exception):
     pass
 
-
 class AnsibleContainerAlreadyInitializedException(Exception):
     pass
 

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -2,7 +2,7 @@ ansible-container:
   # If no $DOCKER_HOST then we need to run privileged so we can access /var/run/docker.sock
   {% if not env.DOCKER_HOST %}privileged: true{% endif %}
   image: "{{ builder_img_id }}"
-  command: "/usr/local/bin/builder.sh /usr/local/bin/ansible-playbook {% if params.debug %}-vvv{% endif %} -i /etc/ansible/ansible-container-inventory.py -c docker {{ params.ansible_options | join(' ')  }} main.yml"
+  command: "/usr/local/bin/builder.sh /usr/local/bin/ansible-playbook {% if params.debug %}-vvv{% endif %} -i /etc/ansible/ansible-container-inventory.py -c docker {{ params.ansible_options | join(' ')  }} {{ playbook }}"
   environment:
     {% if env.DOCKER_HOST %}- DOCKER_HOST{% else %}- DOCKER_HOST=unix:///var/run/docker.sock{% endif %}
     {% if env.DOCKER_TLS_VERIFY %}- DOCKER_TLS_VERIFY{% endif %}

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -2,7 +2,7 @@ ansible-container:
   # If no $DOCKER_HOST then we need to run privileged so we can access /var/run/docker.sock
   {% if not env.DOCKER_HOST %}privileged: true{% endif %}
   image: "{{ builder_img_id }}"
-  command: /usr/local/bin/builder.sh /usr/local/bin/ansible-playbook -i /etc/ansible/ansible-container-inventory.py -c docker {{ params.ansible_options | join(' ')  }} --list-hosts main.yml
+  command: /usr/local/bin/builder.sh /usr/local/bin/ansible-playbook -i /etc/ansible/ansible-container-inventory.py -c docker {{ params.ansible_options | join(' ')  }} --list-hosts {{ playbook }}
   environment:
     {% if env.DOCKER_HOST %}- DOCKER_HOST{% else %}- DOCKER_HOST=unix:///var/run/docker.sock{% endif %}
     {% if env.DOCKER_TLS_VERIFY %}- DOCKER_TLS_VERIFY{% endif %}
@@ -10,10 +10,15 @@ ansible-container:
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
     - ANSIBLE_ORCHESTRATED_HOSTS={% for host in hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
+    {% if with_variables %}{% for env_var in with_variables %}
+    - {{ env_var }}
+    {% endfor %}{% endif %}
   volumes:
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/var/run/docker.sock{% endif %}
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z
+    {% if with_volumes %}{% for vol in with_volumes %}
+    - {{ vol }}{% endfor %}{% endif %}
   working_dir: /ansible-container/ansible/
   stdin_open: true
   tty: true

--- a/container/utils.py
+++ b/container/utils.py
@@ -69,7 +69,7 @@ def config_format_version(base_path, config_data=None):
     return int(config_data.pop('version', 1))
 
 
-def assert_initialized(base_path, kwargs):
+def assert_initialized(base_path, playbook='main.yml'):
     '''
     Raise exception if the ansible directory relative to base_path was not initialized.
 


### PR DESCRIPTION
##### ISSUE TYPE
Feature Pull Request

##### SUMMARY
**WIP - do NOT merge**

The following changes create a demonstrable path for re-using existing Ansible content:
 
- Add --playbook option for providing the path to a playbook that exists within the Ansible build container.
- Does not mount the --playbook path, but instead relies on the user to mount the appropriate path using --with-volumes. Based on user feedback, users typically have an existing directory of playbooks that need to be accessible from within the build container.
- Changes --with-volumes and --with-variables to be top level options allowing them to be accessible during both the `build` command and  the `run` command.

TODO:

- Once the above is working, then add a top level section in `container.yml` for specifying the build options.
- Fix existing tests
- Add new tests
- Update docs
- Add a `Using existing playbooks and roles` page or topic on the docs site that explains how it works, and limitations/known issues when using Docker Machine.
 
Here's basically how you can mount an existing playbook dir and role dir, and use a playbook from the playbook dir:

ansible-container --playbook /playbooks/httpd.yml \
--with-volumes ~/projects/playbooks:/playbooks \ 
--with-volumes ~/projects/roles:/roles \
build

This approach gives the user complete control over path names as well. They can also place an ansible.cfg file in the project `ansible` directory to control the `roles_path` and any other settings.




