### PR TITLE
Add --with-volumes and --with-variables to run and shipit.

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -57,6 +57,17 @@ AVAILABLE_COMMANDS = {'help': 'Display this help message',
                       'push': 'Push your built images to a Docker Hub compatible registry',
                       'shipit': 'Generate a deployment playbook to your cloud of choice.'}
 
+def subcmd_common_parsers(parser, subparser, cmd):
+    if cmd in ('build', 'run', 'shipit'):
+        subparser.add_argument('--with-volumes', '-v', action='store', nargs='+',
+                               help=u'Mount one or more volumes to the Ansible Builder Container. '
+                                    u'Specify volumes as strings using the Docker volume format.',
+                               default=[])
+        subparser.add_argument('--with-variables', '-e', action='store', nargs='+',
+                               help=u'Define one or more environment variables in the Ansible '
+                                    u'Builder Container. Format each variable as a key=value string.',
+                               default=[])
+
 def subcmd_init_parser(parser, subparser):
     return
 
@@ -79,14 +90,6 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--local-builder', action='store_true',
                            help=u'Instead of using the Ansible Builder Container '
                                 u'image from Docker Hub, generate one locally.')
-    subparser.add_argument('--with-volumes', '-v', action='append', nargs='+',
-                           help=u'Mount one or more volumes to the Ansible Builder Container. '
-                                u'Specify volumes as strings using the Docker volume format. '
-                                u'Separate multiple volume strings with spaces.')
-    subparser.add_argument('--with-variables', '-e', action='append', nargs='+',
-                           help=u'Define one or more environment variables in the Ansible '
-                                u'Builder Container. Format each variable as a key=value string. '
-                                u'Separate multiple variable strings with spaces.')
     subparser.add_argument('--save-build-container', action='store_true',
                            help=u'Leave the Ansible Builder Container intact upon build completion. '
                                 u'Use for debugging and testing.', default=False)
@@ -96,7 +99,7 @@ def subcmd_build_parser(parser, subparser):
                                 u'use this argument, you will need to use -- to '
                                 u'prefix your extra options. Use this feature with '
                                 u'caution.', default=u'', nargs='*')
-
+    subcmd_common_parsers(parser, subparser, 'build')
 
 def subcmd_run_parser(parser, subparser):
     subparser.add_argument('service', action='store',
@@ -110,6 +113,7 @@ def subcmd_run_parser(parser, subparser):
     subparser.add_argument('-o', '--remove-orphans', action='store_true',
                            help=u'Remove containers for services not defined in container.yml',
                            default=False, dest='remove_orphans')
+    subcmd_common_parsers(parser, subparser, 'run')
 
 def subcmd_stop_parser(parser, subparser):
     subparser.add_argument('service', action='store',
@@ -153,13 +157,9 @@ def subcmd_shipit_parser(parser, subparser):
         engine_parser = se_subparser.add_parser(engine_name, help=engine['help'])
         engine_obj = load_shipit_engine(engine['cls'], base_path=os.getcwd())
         engine_obj.add_options(engine_parser)
+    subcmd_common_parsers(parser, subparser, 'shipit')
 
 def commandline():
-
-    # default_base_path = os.getcwd()
-    # if os.environ.get('ANSIBLE_CONTAINER_PROJECT'):
-    #     default_base_path = os.environ['ANSIBLE_CONTAINER_PROJECT']
-
     parser = argparse.ArgumentParser(description=u'Build, orchestrate, run, and '
                                                  u'ship Docker containers with '
                                                  u'Ansible playbooks')

--- a/container/engine.py
+++ b/container/engine.py
@@ -298,19 +298,7 @@ def cmdrun_build(base_path, engine_name, flatten=True, purge_last=True, local_bu
         logger.info('Starting %s engine to build your images...'
                     % engine_obj.orchestrator_name)
         touched_hosts = engine_obj.hosts_touched_by_playbook()
-        with_volumes = []
-        if kwargs.get('with_volumes'):
-            for vol in kwargs.pop('with_volumes'):
-                with_volumes += vol
-            logger.debug("volumes: %s" % ','.join(with_volumes))
-        with_variables = []
-        if kwargs.get('with_variables'):
-            for env_var in kwargs.pop('with_variables'):
-                with_variables += env_var
-            logger.debug("env variables: %s" % ','.join(with_variables))
-        engine_obj.orchestrate('build', temp_dir, context=dict(rebuild=rebuild,
-                                                               with_volumes=with_volumes,
-                                                               with_variables=with_variables))
+        engine_obj.orchestrate('build', temp_dir, context=dict(rebuild=rebuild))
         if not engine_obj.build_was_successful():
             logger.error('Ansible playbook run failed.')
             if not save_build_container:

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -10,14 +10,14 @@ ansible-container:
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
     - ANSIBLE_ORCHESTRATED_HOSTS={% for host in hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
-    {% if with_variables %}{% for env_var in with_variables %}
+    {% if params.with_variables %}{% for env_var in params.with_variables %}
     - {{ env_var }}
     {% endfor %}{% endif %}
   volumes:
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/var/run/docker.sock{% endif %}
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z
-    {% if with_volumes %}{% for vol in with_volumes %}
+    {% if params.with_volumes %}{% for vol in params.with_volumes %}
     - {{ vol }}{% endfor %}{% endif %}
   working_dir: /ansible-container/ansible/
 {{ config }}

--- a/container/templates/listhosts-docker-compose.j2.yml
+++ b/container/templates/listhosts-docker-compose.j2.yml
@@ -10,10 +10,15 @@ ansible-container:
     - COMPOSE_HTTP_TIMEOUT=3000
     - DOCKER_API_VERSION={{ api_version }}
     - ANSIBLE_ORCHESTRATED_HOSTS={% for host in hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
+    {% if params.with_variables %}{% for env_var in params.with_variables %}
+    - {{ env_var }}
+    {% endfor %}{% endif %}
   volumes:
     {% if not env.DOCKER_HOST %}- /var/run/docker.sock:/var/run/docker.sock{% endif %}
     {% if env.DOCKER_CERT_PATH %}- $DOCKER_CERT_PATH:/docker-certs/:Z{% endif %}
     - {{ base_path }}:/ansible-container/:Z
+    {% if params.with_volumes %}{% for vol in params.with_volumes %}
+    - {{ vol }}{% endfor %}{% endif %}
   working_dir: /ansible-container/ansible/
   stdin_open: true
   tty: true

--- a/docs/rst/reference/build.rst
+++ b/docs/rst/reference/build.rst
@@ -11,7 +11,7 @@ images built for each of the containers in your orchestration. This is analogous
 
 .. option:: --flatten
 
-By default, Ansible container commits the changes your playbook made to the base image,
+By default, Ansible Container commits the changes your playbook made to the base image,
 but it retains the original layers from that base image. Specifying this option, Ansible
 Container flattens the union filesystem of your image to a single layer.
 
@@ -41,25 +41,25 @@ By default, upon successful completion of a build, the previously latest builds 
 your hosts are deleted and purged from the engine. Specifying this option, the prior builds
 are retained.
 
-.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
+.. option:: --save-build-container
 
 **New in version 0.2.0**
 
-Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
-volume format. Separate multiple volume strings with spaces.
+Leave the Ansible Builder Container intact upon build completion. Use for debugging and testing.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
 **New in version 0.2.0**
 
 Define one or more environment variables in the Ansible Builder Container. Format each variable as a
-key=value string. Separate multiple variable strings with spaces.
+key=value string.
 
-.. option:: --save-build-container
+.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
 
 **New in version 0.2.0**
 
-Leave the Ansible Builder Container intact upon build completion. Use for debugging and testing.
+Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
+volume format.
 
 .. option:: ansible_options
 

--- a/docs/rst/reference/run.rst
+++ b/docs/rst/reference/run.rst
@@ -7,6 +7,21 @@ The ``ansible-container run`` command launches the container orchestrator and ru
 your built containers with the configuration in your ``container.yml`` file. This is
 analogous to ``docker-compose run``.
 
+.. note::
+
+    Before starting the application containers, the build container is started, and Ansible Playbook is
+    invoked with the ``--list-hosts`` option to inspect ``main.yml`` and return the list of hosts
+    it touches. When entering the ``run`` command supply the same ``--with-volumes`` and
+    ``--with-variables`` options passed to the``build`` command. This will ensure that ``main.yml``
+    can be parsed and interpreted.
+
+.. option:: -d, --detached
+
+**New in version 0.2.0**
+
+Run the application in detached mode. Containers will execute in the background. Use the ``docker ps`` command
+to check container status. Use ``ansible-container stop`` to stop the containers.
+
 .. option:: --production
 
 By default, any `dev_overrides` you specified in your ``container.yml`` will be
@@ -17,9 +32,16 @@ the production configuration by using this flag.
 
 Remove containers for services not defined in container.yml.
 
-.. option:: -d, --detached
+.. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
 **New in version 0.2.0**
 
-Run the application in detached mode. Containers will execute in the background. Use the ``docker ps`` command
-to check container status. Use ``ansible-container stop`` to stop the containers.
+Define one or more environment variables in the Ansible Builder Container. Format each variable as a
+key=value string.
+
+.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
+
+**New in version 0.2.0**
+
+Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
+volume format.

--- a/docs/rst/reference/shipit/kube.rst
+++ b/docs/rst/reference/shipit/kube.rst
@@ -8,6 +8,14 @@ application on Kubernetes. The playbook and role are created in the ansible dire
 is *shipit-kubernetes.yml*, and the name of the role is *<project_name>-kubernetes* and can be found in the
 roles directory.
 
+.. note::
+
+    Before ``shipit`` starts, the build container is started, and Ansible Playbook is
+    invoked with the ``--list-hosts`` option to inspect ``main.yml`` and return the list of hosts
+    it touches. When entering the ``run`` command supply the same ``--with-volumes`` and
+    ``--with-variables`` options passed to the``build`` command. This will ensure that ``main.yml``
+    can be parsed and interpreted.
+
 .. option:: --help
 
 Display usage help.
@@ -22,8 +30,19 @@ JSON config file used to create the Kubernetes services and deployments for your
 Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
 pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
 
+.. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
+**New in version 0.2.0**
 
+Define one or more environment variables in the Ansible Builder Container. Format each variable as a
+key=value string.
+
+.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
+
+**New in version 0.2.0**
+
+Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
+volume format.
 
 
 

--- a/docs/rst/reference/shipit/openshift.rst
+++ b/docs/rst/reference/shipit/openshift.rst
@@ -8,6 +8,14 @@ application on Openshift. The playbook and role are created in the ansible direc
 is *shipit-openshift.yml*, and the name of the role is *<project_name>-openshift* and can be found within the
 roles directory.
 
+.. note::
+
+    Before ``shipit`` starts, the build container is started, and Ansible Playbook is
+    invoked with the ``--list-hosts`` option to inspect ``main.yml`` and return the list of hosts
+    it touches. When entering the ``run`` command supply the same ``--with-volumes`` and
+    ``--with-variables`` options passed to the``build`` command. This will ensure that ``main.yml``
+    can be parsed and interpreted.
+
 .. option:: --help
 
 Display usage help.
@@ -22,7 +30,18 @@ JSON config file used to create the openshift services and deployments for your 
 Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
 pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
 
+.. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
+**New in version 0.2.0**
 
+Define one or more environment variables in the Ansible Builder Container. Format each variable as a
+key=value string.
+
+.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
+
+**New in version 0.2.0**
+
+Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
+volume format.
 
 


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### SUMMARY

During the `build`, `run` and `shipit` commands, to get the list of hosts touched by the playbook we invoke Ansible playbook in the build container with the `--list-hosts` option.  For this to work it needs to parse and interpret `main.yml` which may require access to the same `--with-volumes` and `--with-variables` options used to run `build`.

