### PR TITLE
Feature/support requirements.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,7 +196,7 @@ Vagrantfile
 .v8flags*
 
 # shipit output and testing
-roles/
+example/ansible/roles/
 shipit_config/
 shipit*.yml
 tmp.yml

--- a/container/config.py
+++ b/container/config.py
@@ -134,7 +134,7 @@ class AnsibleContainerConfig(Mapping):
                             default_lines.append(re.sub(u'\n', '', line))
                         else:
                             break
-        except OSError:
+        except Exception:
             raise AnsibleContainerConfigException(u"Failed to open %s. Are you in the correct directory?" %
                                                   self.config_path)
 

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -103,11 +103,12 @@ class Engine(BaseEngine):
                                  'Dockerfile')
             tarball.add(os.path.join(temp_dir, 'Dockerfile'),
                         arcname='Dockerfile')
-
             tarball.add(os.path.join(jinja_template_path(), 'builder.sh'),
                         arcname='builder.sh')
             tarball.add(os.path.join(jinja_template_path(), 'ansible-container-inventory.py'),
                         arcname='ansible-container-inventory.py')
+            tarball.add(os.path.join(jinja_template_path(), 'ansible.cfg'),
+                        arcname='ansible.cfg')
             tarball.close()
             tarball_file.close()
             tarball_file = open(tarball_path, 'rb')

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -12,5 +12,6 @@ RUN apt-get update -y && \
 
 ADD builder.sh /usr/local/bin/builder.sh
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
+ADD ansible.cfg /etc/ansible/ansible.cfg
 RUN pip install -q --no-cache-dir ansible==2.1.1.0 PyYAML==3.11
 

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
     apt-get update -y && \
     apt-get install -y python-setuptools git python-pip docker-engine && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    mkdir /etc/ansible/roles
+    mkdir -p /etc/ansible/roles
 
 ADD builder.sh /usr/local/bin/builder.sh
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -7,10 +7,10 @@ RUN apt-get update -y && \
     apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     apt-get update -y && \
     apt-get install -y python-setuptools git python-pip docker-engine && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir /etc/ansible/roles
 
 ADD builder.sh /usr/local/bin/builder.sh
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
-RUN mkdir /etc/ansible/roles
 RUN pip install -q --no-cache-dir ansible==2.1.1.0 PyYAML==3.11
 

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -11,5 +11,6 @@ RUN apt-get update -y && \
 
 ADD builder.sh /usr/local/bin/builder.sh
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
+RUN mkdir /etc/ansible/roles
 RUN pip install -q --no-cache-dir ansible==2.1.1.0 PyYAML==3.11
 

--- a/container/templates/ansible.cfg
+++ b/container/templates/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path=/etc/ansible/roles

--- a/container/templates/ansible.j2.cfg
+++ b/container/templates/ansible.j2.cfg
@@ -1,5 +1,0 @@
-[defaults]
-inventory = /etc/ansible/inventory
-host_key_checking = False
-connection_plugins = /src/ansible/lib/ansible/plugins/connection
-

--- a/container/templates/ansible/ansible.j2.cfg
+++ b/container/templates/ansible/ansible.j2.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path=/etc/ansible/roles

--- a/container/templates/ansible/requirements.j2.yml
+++ b/container/templates/ansible/requirements.j2.yml
@@ -1,0 +1,5 @@
+# Install Ansible Roles
+# ---------------------
+# When the build process starts `ansible-galaxy install -r requirements.yml` is executed
+# using this file. Follow the instructions at http://docs.ansible.com/ansible/galaxy.html
+# to include any roles you want intalled prior to running main.yml.

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 test '(! -f /src/requirements.txt)' || pip install --no-cache-dir -q -U -r /src/requirements.txt
+
+roles=$(python -c "import yaml; roles = yaml.load(open('./requirement.yml', 'r')); print 0 if not roles else len(roles)")
+if [ ${roles} > 0 ]; then
+    ansible-galaxy install -r ./requirements.yml
+fi
+
 "$@"

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -2,7 +2,7 @@
 
 test '(! -f /src/requirements.txt)' || pip install --no-cache-dir -q -U -r /src/requirements.txt
 
-roles=$(python -c "import yaml; roles = yaml.load(open('./requirement.yml', 'r')); print 0 if not roles else len(roles)")
+roles=$(python -c "import yaml; roles = yaml.load(open('./requirements.yml', 'r')); print 0 if not roles else len(roles)")
 if [ ${roles} > 0 ]; then
     ansible-galaxy install -r ./requirements.yml
 fi

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -2,9 +2,11 @@
 
 test '(! -f /src/requirements.txt)' || pip install --no-cache-dir -q -U -r /src/requirements.txt
 
-roles=$(python -c "import yaml; roles = yaml.load(open('./requirements.yml', 'r')); print 0 if not roles else len(roles)")
-if [ ${roles} > 0 ]; then
-    ansible-galaxy install -r ./requirements.yml
+if [ -f "./requirements.yml" ]; then
+    roles=$(python -c "import yaml; roles = yaml.load(open('./requirements.yml', 'r')); print 0 if not roles else len(roles)")
+    if [ "${roles}" -gt 0 ]; then
+        ansible-galaxy install -r ./requirements.yml
+    fi
 fi
 
 "$@"

--- a/docs/rst/index.rst
+++ b/docs/rst/index.rst
@@ -25,6 +25,7 @@ deployment.
    registry_auth
    reference/index
    container_yml/index
+   roles/index
    releases
    Roadmap<roadmaps/index>
    community/index

--- a/docs/rst/reference/run.rst
+++ b/docs/rst/reference/run.rst
@@ -4,7 +4,7 @@ run
 .. program:: ansible-container run
 
 The ``ansible-container run`` command launches the container orchestrator and runs
-your built containers with the configuration in your ``container.yml`` file. This is
+the built containers with the configuration found in ``container.yml``. This is
 analogous to ``docker-compose run``.
 
 .. note::

--- a/docs/rst/reference/shipit/kube.rst
+++ b/docs/rst/reference/shipit/kube.rst
@@ -3,10 +3,9 @@ kube
 
 .. program:: ansible-container shipit kube
 
-The ``ansible-container shipit kube`` command creates an Ansible playbook and role to deploy your
-application on Kubernetes. The playbook and role are created in the ansible directory. The name of the playbook
-is *shipit-kubernetes.yml*, and the name of the role is *<project_name>-kubernetes* and can be found in the
-roles directory.
+The ``ansible-container shipit kube`` command creates in the ``ansible`` directory an Ansible
+playbook and role to deploy your application on Kubernetes. The name of the playbook is
+*shipit-kubernetes.yml*, and the name of the role is *roles/<project_name>-kubernetes*.
 
 .. note::
 

--- a/docs/rst/reference/shipit/openshift.rst
+++ b/docs/rst/reference/shipit/openshift.rst
@@ -3,10 +3,10 @@ openshift
 
 .. program:: ansible-container shipit openshift
 
-The ``ansible-container shipit openshift`` command creates an Ansible playbook and role to deploy your
-application on Openshift. The playbook and role are created in the ansible directory. The name of the playbook
-is *shipit-openshift.yml*, and the name of the role is *<project_name>-openshift* and can be found within the
-roles directory.
+The ``ansible-container shipit openshift`` command creates in the ``ansible`` directory an Ansible
+playbook and role to deploy your application on Openshift. The name of the playbook is
+*shipit-openshift.yml*, and the name of the role is *roles/<project_name>-openshift*.
+
 
 .. note::
 

--- a/docs/rst/roles/existing.rst
+++ b/docs/rst/roles/existing.rst
@@ -1,0 +1,212 @@
+
+Existing Roles
+==============
+
+.. contents:: Topics
+
+
+From the file system
+--------------------
+
+Starting with version 0.2.0 Ansible Container provides the ability to add custom volumes to the Ansible Build Container
+by using the ``--with-volumes`` option. So if you have roles already installed on the local file system, you can simply
+mount the path to the build container.
+
+For example, if roles are installed at /var/roles, the following will make the roles available inside the build container
+as ``/roles``:
+
+.. code-block:: bash
+
+    $ ansible-container build --with-volumes /var/roles:/roles
+
+For the roles to be accessed by Ansible Playbook, add an ``ansible.cfg`` file to the ``ansible`` directory, and set the
+``roles_path``:
+
+.. code-block:: bash
+
+    [defaults]
+    roles_path=/roles
+
+In your ``main.yml`` playbook refer to roles by name. For example, if the role ``geerlingguy.apache`` is installed in /var/roles
+locally, then the following will execute the role as part of ``main.yml``:
+
+.. code-block:: yaml
+
+    - name: Example play
+      hosts: web
+      roles:
+        - name: Install apache
+          role: geerlingguy.apache
+
+.. note::
+
+    If using Docker Machine, be aware that mounting paths outside fo the user's home directory to a container may
+    require additional steps. For more details see the Docker tutorial, `Manage data in containers <https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume>`_.
+
+.. note::
+
+    If you choose to access locally installed roles using ``--with-volumes``, then you must include the same volumes for 
+    the ``run`` and ``shipit`` commands as you did for ``build``. During these operations the ``main.yml`` playbook is
+    accessed using the ``--list-hosts`` option to determine the list of hosts affected by the playbook. If roles cannot be
+    accessed, Ansible Playbook will fail to parse ``main.yml``.
+
+
+From Galaxy and version control
+-------------------------------
+
+Starting in version 0.2.0 Ansible Container will automatically install roles included in a ``requirements.yml`` file placed in
+the ``ansible`` directory. If you are unfamiliar with ``requirements.yml``, see `Installing Multiple Roles From a File <http://docs.ansible.com/ansible/galaxy.html#installing-multiple-roles-from-a-file>`_.
+
+The default ``roles_path`` is set to ``/etc/ansible/roles`` on the build container, and roles will be installed there. No special
+changes are required in ``main.yml``. To run an installed role simply refer to it by name.
+
+
+Making roles *container safe*
+-----------------------------
+
+If you're new to managing the application lifecycle through containers, it's almost certain that any roles you've written in the
+past were not written from the perspective of running inside a container and with the intent of producing a container image.
+Making a role *container safe* is just a name for the process of reviewing a role and disabling or removing tasks that won't work
+or don't make sense in a containerized infrastructure.
+
+Here are some things to consider and review before attempting to build an image with an existing Ansible role:
+
+Eliminate what doesn't work
+```````````````````````````
+
+Sometimes things just don't work in a container. For example, unless the container has an init system, the ``service`` module
+will not work. Lots of roles install a software package and then either as a final task or by way of a handler, call the ``service``
+module to start and enable the newly installed service. In cases like this, where you know the module will not work in a container,
+you can completely remove it, or you can disable for containers by testing ``ansible_connection``. If the task is being executed
+through the Docker connection plugin, it will be set to ``docker``.
+
+For example, the following will only call the ``service`` module to start the apache service if ``ansible_connection`` is not equal
+to ``docker``:
+
+.. code-block:: yaml
+
+    - name: Start and enable apache
+      service: name=apache state=restarted enabled=yes
+      when: ansible_connection != 'docker'
+
+Ansible Container relies on the Docker connection plugin to communicate from the build container to the containers making up
+the application, so all of the tasks and roles in ``main.yml`` will have ``ansible_connection`` set to ``docker``.
+
+Clean up the filesystem
+```````````````````````
+
+Another thing to consider when executing a role within a container is the size of the final image. Ansible Container starts with
+a base image and adds a layer to it. What's in that layer is the result of all the tasks executed in ``main.yml``, including any files
+downloaded or copied files.
+
+Lots of tasks download archive files, especially package managers, and either keep them in a cache directory or never clean up
+after themselves. This might be OK and even beneficial within a virtual machine, but within a container it will produce a bloated image.
+
+Check the package manager you're using, and as a final step to updating and installing packages, run the command that cleans up the
+cache. In the case of Yum, you might do the following:
+
+.. code-block:: yaml
+
+    - name: Update all packages
+      yum: name=* state=latest
+
+    - name: Install mysql
+      yum: name=mysql-server state=present
+
+    - name: Purge yum cache
+      command: yum clean all
+
+Another culprit is get_url. Make sure any .rpm or .deb files are removed after installation. For example, installing filebeat in a
+Debian container might look like the following:
+
+.. code-block:: yaml
+
+    - name: Download filebeat
+      get_url: url=https://download.elastic.co/beats/filebeat/filebeat_1.0.1_amd64.deb dest=/filebeat_1.0.1_amd64.deb mode=0664
+
+    - name: Install filebeat
+      apt: deb=/filebeat_1.0.1_amd64.deb
+
+    - name: Remove package file
+      file: path=/filebeat_1.0.1_amd64.deb state=absent
+
+
+Run a single service only
+`````````````````````````
+
+A production container can only execute a single service. Many roles are written to run a stack of services. Take for example
+the LAMP stack. A role will typically install Apache, MySQL and possibly supporting services like iptables. That works great
+for a virtual machine, however a container is intended to run only a single service. What we really need is two roles, one for
+Apache and a completely separate role for MySQL. So if you have roles like this, you'll need to split them apart into multiple
+roles.
+
+Make images that don't require root
+```````````````````````````````````
+
+A production container never executes as the root user. When we're building a container for the purpose of creating an image,
+it's OK to run as root, but any container created from the resulting image should not run as root.
+
+It's very likely that your existing roles do not take this into account as Virtual machines generally start processes as root
+and then ``su`` to a user account. Take the case of MySQL. On a Centos 7 virtual machine you would start the process by running:
+``sudo systemctl start mysqld``. This will invoke an init script as root, do any pre-launch tasks, and then launch the mysqld
+process as the mysql user.
+
+A role tasked with installing and configuring MySQL within a container should include setting file system permissions so that
+everything in the final image can be executed as a non-privileged user.
+
+Be careful with credentials
+```````````````````````````
+
+Remove any tasks that write credentials to the filesystem. For example, you might have a role that creates a ``.pgpass`` file,
+making it possible to access a Postgresql database without a password. To avoid accidentally exposing passwords, define
+environment variables in your ``container.yml`` and provide the values using ``--var-file`` or environment variables:
+
+In ``container.yl`` you might have the following:
+
+.. code-block:: yaml
+
+    services:
+        web:
+            environment:
+                - POSTGRES_USERNAME={{ postgres_username }}
+                - POSTGRES_PASSWORD={{ postgres_password }}
+
+In a variable file called `develop.yml`, you could provided the username and password values:
+
+.. code-block:: yaml
+
+    ---
+    postgres_username: admin
+    postgres_password: mypassword
+
+
+.. code-block:: bash
+
+Then pass in the variable file using ``--var-file``:
+
+    $ ansible-container --var-file develop.yml build
+
+Or as an alternative to a variable file, pass in the values using ``AC_`` environment variables:
+
+.. code-block:: bash
+
+    $ export AC_POSTGRES_USERNAME=admin
+    $ export AC_POSTGRES_PASSWORD=mypassword
+    $ ansible-container build
+
+Be immutable
+````````````
+
+Containers are meant to be immutable, which means log files and data should `not` be be stored on the container's filesystem. A
+role author should therefore think about configuring the service in such a way that it's easy for an image user to mount
+custom volumes to collect log files and data, and if necessary makes changes to how and where data is written simply by setting
+environment variables.
+
+Don't rely on IP addresses
+``````````````````````````
+
+Virtual machines generally have a hostname that doesn't change and often times a static IP address, so an entry
+in ``/etc/hosts`` is all that's needed to facilitate communication. A container's IP address and possibly it's name will change
+every time it gets restarted or recreated, so communication is facilitated by way of environment variables. An application
+within a container will typically get the name of a host and port by looking at environment variables. Make sure your role is
+not adding entries to ``/etc/hosts`` or hard-coding container names and IP addresses into configuration files.

--- a/docs/rst/roles/galaxy.rst
+++ b/docs/rst/roles/galaxy.rst
@@ -1,0 +1,3 @@
+NEW: Galaxy Integration
+=======================
+

--- a/docs/rst/roles/index.rst
+++ b/docs/rst/roles/index.rst
@@ -1,0 +1,8 @@
+Ansible Roles
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   existing
+   galaxy

--- a/test/integration/projects/requirements/ansible/container.yml
+++ b/test/integration/projects/requirements/ansible/container.yml
@@ -1,0 +1,9 @@
+version: "1"
+services:
+  web:
+      image: centos:7
+      ports:
+        - "8000:80"
+      command: ['sleep 600']
+
+registries: {}

--- a/test/integration/projects/requirements/ansible/main.yml
+++ b/test/integration/projects/requirements/ansible/main.yml
@@ -1,0 +1,3 @@
+- name: Empty play
+  hosts: all
+  tasks:

--- a/test/integration/projects/requirements/ansible/requirements.txt
+++ b/test/integration/projects/requirements/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.8.0

--- a/test/integration/projects/requirements/ansible/requirements.yml
+++ b/test/integration/projects/requirements/ansible/requirements.yml
@@ -1,0 +1,6 @@
+# Install Ansible Roles
+# ---------------------
+# When the build process starts `ansible-galaxy install -r requirements.yml` is executed
+# using this file. Follow the instructions at http://docs.ansible.com/ansible/galaxy.html
+# to include any roles you want intalled prior to running main.yml.
+- src: https://github.com/chouseknecht/ansible-role-apache

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -123,6 +123,12 @@ def test_run_with_var_file():
     assert "ansible_db_1 exited with code 0" in result.stdout
     assert "ansible_web_1 exited with code 0" in result.stdout
 
+def test_install_role_requirements():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', '--debug', 'build',
+                     cwd=project_dir('requirements'), expect_stderr=True)
+    assert "ansible-role-apache was installed successfully" in result.stderr
+
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()
 #    result = env.run('ansible-container', 'shipit', 'kube', cwd=project_dir('minimal'), expect_error=True)


### PR DESCRIPTION
##### ISSUE TYPE
Feature Pull Request
 
##### SUMMARY
Add support for ansible/requirements.yml per #221. Adds requirements.yml to `ansible` directory. If user adds roles, they will be automatically installed to /etc/ansbile/roles. Latest build container image includes /etc/ansible/roles directory and /etc/ansible/ansible.cfg with roles_path=/etc/ansible/roles.

Added a default ansible.cfg to `ansible` directory. Defaults roles_path=/etc/ansible/roles. User can of course override this. 

Added copious amounts of documentation under rst/roles regarding how to use existing roles from file system or VCS.