### PR TITLE
Prevent build container race condition

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -105,6 +105,8 @@ class Engine(BaseEngine):
                         arcname='Dockerfile')
             tarball.add(os.path.join(jinja_template_path(), 'builder.sh'),
                         arcname='builder.sh')
+            tarball.add(os.path.join(jinja_template_path(), 'wait_on_host.py'),
+                        arcname='wait_on_host.py')
             tarball.add(os.path.join(jinja_template_path(), 'ansible-container-inventory.py'),
                         arcname='ansible-container-inventory.py')
             tarball.add(os.path.join(jinja_template_path(), 'ansible.cfg'),

--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -11,6 +11,7 @@ RUN apt-get update -y && \
     mkdir -p /etc/ansible/roles
 
 ADD builder.sh /usr/local/bin/builder.sh
+ADD wait_on_host.py /usr/local/bin/wait_on_host.py
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
 ADD ansible.cfg /etc/ansible/ansible.cfg
 RUN pip install -q --no-cache-dir ansible==2.1.1.0 PyYAML==3.11

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -10,7 +10,7 @@ if [ -f "./requirements.yml" ]; then
 fi
 
 if [ "$ANSIBLE_ORCHESTRATED_HOSTS" != "" ]; then
-    /usr/local/bin/wait_on_host.py $(echo $ANSIBLE_ORCHESTRATED_HOSTS | tr "," " ")
+    /usr/local/bin/wait_on_host.py -m 5 $(echo $ANSIBLE_ORCHESTRATED_HOSTS | tr "," " ")
 fi
 
 "$@"

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -9,4 +9,8 @@ if [ -f "./requirements.yml" ]; then
     fi
 fi
 
+if [ "$ANSIBLE_ORCHESTRATED_HOSTS" != "" ]; then
+    /usr/local/bin/wait_on_host.py $(echo $ANSIBLE_ORCHESTRATED_HOSTS | tr "," " ")
+fi
+
 "$@"

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -9,8 +9,9 @@ if [ -f "./requirements.yml" ]; then
     fi
 fi
 
-if [ "$ANSIBLE_ORCHESTRATED_HOSTS" != "" ]; then
-    /usr/local/bin/wait_on_host.py -m 5 $(echo $ANSIBLE_ORCHESTRATED_HOSTS | tr "," " ")
+if [ "${ANSIBLE_ORCHESTRATED_HOSTS}" != "" ]; then
+    # shellcheck disable=SC2046
+    /usr/local/bin/wait_on_host.py -m 5 $(echo "${ANSIBLE_ORCHESTRATED_HOSTS}" | tr ',' ' ')
 fi
 
 "$@"

--- a/container/templates/wait_on_host.py
+++ b/container/templates/wait_on_host.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import subprocess
+import argparse
+import sys
+from subprocess import CalledProcessError, STDOUT
+from time import sleep
+
+
+def wait_on_hosts(hosts, max_attempts=3, sleep_time=1):
+    '''
+    Wait for a container to have a State.Running value = true.
+    :param hosts: list of service names taken from container.yml
+    :param max_attempts: Max number of times to inspect the container and check State.Running
+    :param sleep_time: Number of seconds to wait between attempts.
+    :return: dict of host:running pairs
+    '''
+    results = {}
+    for host in hosts:
+        container = "ansible_{}_1".format(host)
+        tries = max_attempts
+        host_ready = False
+        output = None
+        while tries > 0 and not host_ready:
+            try:
+                output = subprocess.check_output(["docker", "inspect", "--format", "{{ .State.Running }}",
+                                                  container], stderr=STDOUT)
+            except CalledProcessError:
+                pass
+            tries -= 1
+            if output and 'true' in output:
+                host_ready = True
+                results[host] = True
+            else:
+                sleep(sleep_time)
+        if not host_ready:
+            results[host] = False
+    return results
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(prog='wait_on_host',
+                                     description='Wait for a host or list of hosts to be in a running state')
+    parser.add_argument('--max-attempts', '-m', type=int, action='store', default=3,
+                        help=u"max number of attempts at checking a container's state, defaults to 3")
+    parser.add_argument('--sleep-time', '-s', type=int, action='store', default=1,
+                        help=u'number of seconds to wait between attempts, defaults to 1')
+    parser.add_argument('host', nargs='+',
+                        help=u'name of the host to wait on')
+    args = parser.parse_args()
+
+    if args.host:
+        results = wait_on_hosts(args.host, max_attempts=args.max_attempts, sleep_time=args.sleep_time)
+        status = 0
+        for host, running in results.iteritems():
+            print "Host {0} {1}".format(host, 'running' if running else 'failed')
+            if not running:
+                status = 1
+        sys.exit(status)

--- a/container/templates/wait_on_host.py
+++ b/container/templates/wait_on_host.py
@@ -21,6 +21,7 @@ def wait_on_hosts(hosts, max_attempts=3, sleep_time=1):
         tries = max_attempts
         host_ready = False
         output = None
+        results[host] = False
         while tries > 0 and not host_ready:
             try:
                 output = subprocess.check_output(["docker", "inspect", "--format", "{{ .State.Running }}",
@@ -33,8 +34,6 @@ def wait_on_hosts(hosts, max_attempts=3, sleep_time=1):
                 results[host] = True
             else:
                 sleep(sleep_time)
-        if not host_ready:
-            results[host] = False
     return results
 
 if __name__ == '__main__':

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -129,6 +129,7 @@ def test_install_role_requirements():
                      cwd=project_dir('requirements'), expect_stderr=True)
     assert "ansible-role-apache was installed successfully" in result.stderr
 
+@pytest.mark.timeout(240)
 def test_setting_ansible_container_envar():
     env = ScriptTestEnvironment()
     result = env.run('ansible-container', '--debug', 'build',


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### SUMMARY
- Adds wait_on_host.py script to build container.
- Updates builder.sh to call wait_on_host.py for each host that will be touched by the playbook.
- Prevents playbook execution from starting until all of the hosts are in a running state.
- Fixes #234