### PR TITLE
edit requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-docker-compose==1.7.0
-docker-py==1.8.0
-Jinja2==2.8
-PyYAML==3.11
-requests==2.7.0
+docker-compose>=1.7.0
+Jinja2>=2.8
+PyYAML>=3.11


### PR DESCRIPTION
##### ISSUE TYPE
- Bug Pull Request
##### SUMMARY

I was trying build the RPM for ansible-containers and I figured out that it makes it difficult to install the RPM, if we have such rigid coupling of dependencies.
If we update the requirements.txt to not look for the exact versions of dependencies but something like,

```
docker-compose>=1.7.0
```

 then we can RPM install successfully.   
