### PR TITLE
shipit --save config via kompose, fix #233

### DIFF
--- a/container/shipit/kubernetes/engine.py
+++ b/container/shipit/kubernetes/engine.py
@@ -2,21 +2,28 @@
 
 from __future__ import absolute_import
 
+from compose.cli.command import project_from_options
+from compose.cli import main
 import logging
 import os.path
-import json
+import yaml
 
 from ..base_engine import BaseShipItEngine
 from .deployment import Deployment
 from .service import Service
 from ..utils import create_path
 from ..constants import SHIPIT_PATH, SHIPIT_CONFIG_PATH
+from ...utils import jinja_render_to_temp
+from ...temp import MakeTempDir as make_temp_dir
+from ...docker.engine import Engine
 
 logger = logging.getLogger(__name__)
 
 
 class ShipItEngine(BaseShipItEngine):
     name = u'kubernetes'
+    builder_container_img = 'ansible-container-builder'
+    builder_container_img_tag = '0.2-kompose-v0.1.0'
 
     def add_options(self, subparser):
         super(ShipItEngine, self).add_options(subparser)
@@ -33,19 +40,41 @@ class ShipItEngine(BaseShipItEngine):
         dest_path = os.path.join(self.base_path, SHIPIT_PATH, SHIPIT_CONFIG_PATH, self.name)
         create_path(dest_path)
 
-        templates = Service(config=self.config, project_name=self.project_name).get_template()
-        for template in templates:
-            name = "%s-service.json" % template['metadata']['name']
-            with open(os.path.join(dest_path, name), 'w') as f:
-                f.write(json.dumps(template, indent=4))
+        with make_temp_dir() as temp_dir:
+            with open(os.path.join(temp_dir, 'docker-compose.yml'), 'w') as f:
+                f.write(yaml.safe_dump(self.config.get('services')))
 
-        templates = Deployment(config=self.config, project_name=self.project_name).get_template()
-        for template in templates:
-            name = "%s-deployment.json" % template['metadata']['name']
-            with open(os.path.join(dest_path, name), 'w') as f:
-                f.write(json.dumps(template, indent=4))
+            jinja_render_to_temp('shipit-kompose-docker-compose.j2.yml',
+                                 temp_dir,
+                                 'shipit-kompose-compose.yml',
+                                 builder_img_id="containscafeine/{}:{}".format(
+                                     self.builder_container_img,
+                                     self.builder_container_img_tag),
+                                 host_dir=temp_dir)
+
+            options = Engine.DEFAULT_COMPOSE_OPTIONS.copy()
+
+            options.update({
+                u'--file': [
+                    os.path.join(temp_dir,
+                                 'shipit-kompose-compose.yml')],
+                u'--project-name': 'ansible',
+            })
+
+            command_options = Engine.DEFAULT_COMPOSE_UP_OPTIONS.copy()
+
+            project = project_from_options(self.base_path + '/ansible', options)
+            command = main.TopLevelCommand(project)
+
+            options.update({u'COMMAND': 'up'})
+
+            command.up(command_options)
+
+            with open(os.path.join(temp_dir, 'artifacts.yml'), 'r') as f:
+                artifacts = f.read()
+
+            with open(os.path.join(dest_path, 'deployment_artifacts.yml'),
+                      'w') as f:
+                f.write(artifacts)
 
         return dest_path
-
-
-

--- a/container/shipit/openshift/engine.py
+++ b/container/shipit/openshift/engine.py
@@ -2,9 +2,11 @@
 
 from __future__ import absolute_import
 
+from compose.cli.command import project_from_options
+from compose.cli import main
 import logging
 import os.path
-import json
+import yaml
 
 from ..base_engine import BaseShipItEngine
 from .deployment import Deployment
@@ -12,12 +14,17 @@ from .route import Route
 from .service import Service
 from ..utils import create_path
 from ..constants import SHIPIT_PATH, SHIPIT_CONFIG_PATH
+from ...utils import jinja_render_to_temp
+from ...temp import MakeTempDir as make_temp_dir
+from ...docker.engine import Engine
 
 logger = logging.getLogger(__name__)
 
 
 class ShipItEngine(BaseShipItEngine):
     name = u'openshift'
+    builder_container_img = 'ansible-container-builder'
+    builder_container_img_tag = '0.2-kompose-v0.1.0'
 
     def add_options(self, subparser):
         super(ShipItEngine, self).add_options(subparser)
@@ -35,23 +42,43 @@ class ShipItEngine(BaseShipItEngine):
         dest_path = os.path.join(self.base_path, SHIPIT_PATH, SHIPIT_CONFIG_PATH, self.name)
         create_path(dest_path)
 
-        templates = Service(config=self.config, project_name=self.project_name).get_template()
-        for template in templates:
-            name = "%s-service.json" % template['metadata']['name']
-            with open(os.path.join(dest_path, name), 'w') as f:
-                f.write(json.dumps(template, indent=4))
+        with make_temp_dir() as temp_dir:
+            with open(os.path.join(temp_dir, 'docker-compose.yml'), 'w') as f:
+                f.write(yaml.safe_dump(self.config.get('services')))
 
-        templates = Route(config=self.config, project_name=self.project_name).get_template()
-        for template in templates:
-            name = "%s.json" % template['metadata']['name']
-            with open(os.path.join(dest_path, name), 'w') as f:
-                f.write(json.dumps(template, indent=4))
+            jinja_render_to_temp('shipit-kompose-docker-compose.j2.yml',
+                                 temp_dir,
+                                 'shipit-kompose-compose.yml',
+                                 builder_img_id="containscafeine/{}:{}".format(
+                                     self.builder_container_img,
+                                     self.builder_container_img_tag),
+                                 host_dir=temp_dir,
+                                 is_openshift=True)
 
-        templates = Deployment(config=self.config, project_name=self.project_name).get_template()
-        for template in templates:
-            name = "%s-deployment.json" % template['metadata']['name']
-            with open(os.path.join(dest_path, name), 'w') as f:
-                f.write(json.dumps(template, indent=4))
+            options = Engine.DEFAULT_COMPOSE_OPTIONS.copy()
+
+            options.update({
+                u'--file': [
+                    os.path.join(temp_dir,
+                                 'shipit-kompose-compose.yml')],
+                u'--project-name': 'ansible',
+            })
+
+            command_options = Engine.DEFAULT_COMPOSE_UP_OPTIONS.copy()
+
+            project = project_from_options(self.base_path + '/ansible', options)
+            command = main.TopLevelCommand(project)
+
+            options.update({u'COMMAND': 'up'})
+
+            command.up(command_options)
+
+            with open(os.path.join(temp_dir, 'artifacts.yml'), 'r') as f:
+                artifacts = f.read()
+
+            with open(os.path.join(dest_path, 'deployment_artifacts.yml'),
+                      'w') as f:
+                f.write(artifacts)
 
         return dest_path
 

--- a/container/templates/ansible-kompose-dockerfile.j2
+++ b/container/templates/ansible-kompose-dockerfile.j2
@@ -1,0 +1,7 @@
+FROM ansible/ansible-container-builder:0.2
+
+# Fetch kompose
+ADD https://github.com/skippbox/kompose/releases/download/v0.1.0/kompose_linux-amd64.tar.gz /tmp/
+
+# Decompress and add binary to $PATH
+RUN tar xzf /tmp/kompose_linux-amd64.tar.gz --strip-components 1 -C /usr/bin/

--- a/container/templates/ansible-kompose-dockerfile.j2
+++ b/container/templates/ansible-kompose-dockerfile.j2
@@ -1,7 +1,4 @@
 FROM ansible/ansible-container-builder:0.2
 
-# Fetch kompose
-ADD https://github.com/skippbox/kompose/releases/download/v0.1.0/kompose_linux-amd64.tar.gz /tmp/
-
-# Decompress and add binary to $PATH
-RUN tar xzf /tmp/kompose_linux-amd64.tar.gz --strip-components 1 -C /usr/bin/
+# Fetch kompose, decomporess, add binary to $PATH
+RUN curl -L https://github.com/skippbox/kompose/releases/download/v0.1.0/kompose_linux-amd64.tar.gz -o /tmp/kompose_linux-amd64.tar.gz && tar xzf /tmp/kompose_linux-amd64.tar.gz --strip-components 1 -C /usr/bin/ && rm -f  /tmp/kompose_linux-amd64.tar.gz

--- a/container/templates/ansible-kompose-dockerfile.j2
+++ b/container/templates/ansible-kompose-dockerfile.j2
@@ -1,4 +1,8 @@
 FROM ansible/ansible-container-builder:0.2
 
-# Fetch kompose, decomporess, add binary to $PATH
-RUN curl -L https://github.com/skippbox/kompose/releases/download/v0.1.0/kompose_linux-amd64.tar.gz -o /tmp/kompose_linux-amd64.tar.gz && tar xzf /tmp/kompose_linux-amd64.tar.gz --strip-components 1 -C /usr/bin/ && rm -f  /tmp/kompose_linux-amd64.tar.gz
+# Fetch kompose, decompress, add binary to $PATH
+RUN curl -L \
+    https://github.com/skippbox/kompose/releases/download/v0.1.0/kompose_linux-amd64.tar.gz \
+    -o /tmp/kompose_linux-amd64.tar.gz && \
+    tar xzf /tmp/kompose_linux-amd64.tar.gz --strip-components 1 -C /usr/bin/ && \
+    rm -f  /tmp/kompose_linux-amd64.tar.gz

--- a/container/templates/shipit-kompose-docker-compose.j2.yml
+++ b/container/templates/shipit-kompose-docker-compose.j2.yml
@@ -1,0 +1,5 @@
+ansible-container-kompose:
+  image: {{ builder_img_id }}
+  command: "kompose -f /tmp/docker-compose.yml convert --yaml {% if is_openshift %} --dc {% endif %} -o /tmp/artifacts.yml"
+  volumes:
+    - {{ host_dir }}:/tmp/

--- a/test/integration/projects/minimal2_v1/ansible/container.yml
+++ b/test/integration/projects/minimal2_v1/ansible/container.yml
@@ -1,0 +1,14 @@
+version: "1"
+services:
+  minimal1:
+    image: busybox
+    command: sleep 1d
+    ports:
+      - '80:8080'
+  minimal2:
+    image: busybox
+    command: sleep 1d
+    links:
+      - minimal1
+    ports:
+      - '443:8443'

--- a/test/integration/projects/minimal2_v1/desired_k8s.yml
+++ b/test/integration/projects/minimal2_v1/desired_k8s.yml
@@ -1,0 +1,91 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal1
+    name: minimal1
+  spec:
+    ports:
+    - name: "80"
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      service: minimal1
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal2
+    name: minimal2
+  spec:
+    ports:
+    - name: "443"
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    selector:
+      service: minimal2
+  status:
+    loadBalancer: {}
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: minimal1
+  spec:
+    replicas: 1
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          service: minimal1
+      spec:
+        containers:
+        - args:
+          - sleep
+          - 1d
+          image: busybox
+          name: minimal1
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+        restartPolicy: Always
+  status: {}
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: minimal2
+  spec:
+    replicas: 1
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          service: minimal2
+      spec:
+        containers:
+        - args:
+          - sleep
+          - 1d
+          image: busybox
+          name: minimal2
+          ports:
+          - containerPort: 8443
+            protocol: TCP
+          resources: {}
+        restartPolicy: Always
+  status: {}
+kind: List
+metadata: {}
+

--- a/test/integration/projects/minimal2_v1/desired_oc.yml
+++ b/test/integration/projects/minimal2_v1/desired_oc.yml
@@ -1,0 +1,105 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal2
+    name: minimal2
+  spec:
+    ports:
+    - name: "443"
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    selector:
+      service: minimal2
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal1
+    name: minimal1
+  spec:
+    ports:
+    - name: "80"
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      service: minimal1
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal2
+    name: minimal2
+  spec:
+    replicas: 1
+    selector:
+      service: minimal2
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          service: minimal2
+      spec:
+        containers:
+        - args:
+          - sleep
+          - 1d
+          image: busybox
+          name: minimal2
+          ports:
+          - containerPort: 8443
+            protocol: TCP
+          resources: {}
+        restartPolicy: Always
+    test: false
+    triggers: null
+  status: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      service: minimal1
+    name: minimal1
+  spec:
+    replicas: 1
+    selector:
+      service: minimal1
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          service: minimal1
+      spec:
+        containers:
+        - args:
+          - sleep
+          - 1d
+          image: busybox
+          name: minimal1
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+        restartPolicy: Always
+    test: false
+    triggers: null
+  status: {}
+kind: List
+metadata: {}
+

--- a/test/integration/test_fast.py
+++ b/test/integration/test_fast.py
@@ -19,65 +19,68 @@ def test_no_command_shows_help():
 
 def test_help_command_shows_help():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'help')
+    result = env.run('ansible-container', 'help', expect_stderr=True)
     assert "usage: ansible-container" in result.stdout
 
 
 def test_help_option_shows_help():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', '--help')
+    result = env.run('ansible-container', '--help', expect_stderr=True)
     assert "usage: ansible-container" in result.stdout
 
 
 def test_help_option_shows_help_for_run_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'run', '--help')
+    result = env.run('ansible-container', 'run', '--help', expect_stderr=True)
     assert "usage: ansible-container run" in result.stdout
 
 
 def test_help_option_shows_help_for_stop_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'stop', '--help')
+    result = env.run('ansible-container', 'stop', '--help', expect_stderr=True)
     assert "usage: ansible-container stop" in result.stdout
 
 
 def test_help_option_shows_help_for_restart_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'restart', '--help')
+    result = env.run('ansible-container', 'restart', '--help',
+                     expect_stderr=True)
     assert "usage: ansible-container restart" in result.stdout
 
 
 def test_help_option_shows_help_for_help_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'help', '--help')
+    result = env.run('ansible-container', 'help', '--help', expect_stderr=True)
     assert "usage: ansible-container help" in result.stdout
 
 
 def test_help_option_shows_help_for_shipit_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'shipit', '--help')
+    result = env.run('ansible-container', 'shipit', '--help',
+                     expect_stderr=True)
     assert "usage: ansible-container shipit" in result.stdout
 
 def test_help_option_shows_help_for_shipit_engine_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'shipit', 'kube', '--help')
+    result = env.run('ansible-container', 'shipit', 'kube', '--help',
+                     expect_stderr=True)
     assert "usage: ansible-container shipit kube" in result.stdout
 
 def test_help_option_shows_help_for_init_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'init', '--help')
+    result = env.run('ansible-container', 'init', '--help', expect_stderr=True)
     assert "usage: ansible-container init" in result.stdout
 
 
 def test_help_option_shows_help_for_build_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'build', '--help')
+    result = env.run('ansible-container', 'build', '--help', expect_stderr=True)
     assert "usage: ansible-container build" in result.stdout
 
 
 def test_help_option_shows_help_for_push_command():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'push', '--help')
+    result = env.run('ansible-container', 'push', '--help', expect_stderr=True)
     assert "usage: ansible-container push" in result.stdout
 
 

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -114,7 +114,7 @@ def test_restart_service_minimal_docker_container():
     assert "Restarting ansible_minimal1_1 ... done" in result.stderr
     assert "Restarting ansible_minimal2_1 ... done" not in result.stderr
     env.run('ansible-container', 'stop', '-f',
-            cwd=project_dir('minimal_sleep'))
+            cwd=project_dir('minimal_sleep'), expect_stderr=True)
 
 def test_build_with_var_file():
     env = ScriptTestEnvironment()

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -103,8 +103,8 @@ def test_restart_minimal_docker_container():
     result = env.run('ansible-container', 'restart', cwd=project_dir('minimal_sleep'), expect_stderr=True)
     assert "Restarting ansible_minimal1_1 ... done" in result.stderr
     assert "Restarting ansible_minimal2_1 ... done" in result.stderr
-    env.run('ansible-container', 'stop', cwd=project_dir('minimal_sleep'),
-            expect_stderr=True)
+    env.run('ansible-container', 'stop', '-f',
+            cwd=project_dir('minimal_sleep'), expect_stderr=True)
 
 
 def test_restart_service_minimal_docker_container():
@@ -113,7 +113,8 @@ def test_restart_service_minimal_docker_container():
     result = env.run('ansible-container', 'restart', 'minimal1', cwd=project_dir('minimal_sleep'), expect_stderr=True)
     assert "Restarting ansible_minimal1_1 ... done" in result.stderr
     assert "Restarting ansible_minimal2_1 ... done" not in result.stderr
-
+    env.run('ansible-container', 'stop', '-f',
+            cwd=project_dir('minimal_sleep'))
 
 def test_build_with_var_file():
     env = ScriptTestEnvironment()

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import json
 import yaml
 from scripttest import TestFileEnvironment as ScriptTestEnvironment  # rename to avoid pytest collect warning
 
@@ -147,7 +146,7 @@ def test_setting_ansible_container_envar():
 
 def test_shipit_save_config_kube():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'shipit', 'kube', '--save-config',
+    result = env.run('ansible-container', '--debug', 'shipit', 'kube', '--save-config',
                      cwd=project_dir('minimal2_v1'), expect_stderr=True)
     assert "Saved configuration to" in result.stderr
 
@@ -162,7 +161,7 @@ def test_shipit_save_config_kube():
 
 def test_shipit_save_config_openshift():
     env = ScriptTestEnvironment()
-    result = env.run('ansible-container', 'shipit', 'openshift', '--save-config',
+    result = env.run('ansible-container', '--debug', 'shipit', 'openshift', '--save-config',
                      cwd=project_dir('minimal2_v1'), expect_stderr=True)
     assert "Saved configuration to" in result.stderr
 

--- a/test/integration/test_slow.py
+++ b/test/integration/test_slow.py
@@ -1,6 +1,7 @@
 import os
 import pytest
-
+import json
+import yaml
 from scripttest import TestFileEnvironment as ScriptTestEnvironment  # rename to avoid pytest collect warning
 
 
@@ -8,6 +9,12 @@ def project_dir(name):
     test_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_dir, 'projects', name)
 
+def order_dict_or_list(to_order):
+    if isinstance(to_order, dict):
+        return sorted((k, order_dict_or_list(v)) for k, v in to_order.items())
+    if isinstance(to_order, list):
+        return sorted(order_dict_or_list(x) for x in to_order)
+    return to_order
 
 @pytest.mark.timeout(240)
 def test_build_minimal_docker_container():
@@ -137,6 +144,36 @@ def test_setting_ansible_container_envar():
     assert "web MYVAR=foo ANSIBLE_CONTAINER=1" in result.stdout
     assert "db MYVAR=foo ANSIBLE_CONTAINER=1" in result.stdout
     assert "mw ANSIBLE_CONTAINER=1" in result.stdout
+
+def test_shipit_save_config_kube():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', 'shipit', 'kube', '--save-config',
+                     cwd=project_dir('minimal2_v1'), expect_stderr=True)
+    assert "Saved configuration to" in result.stderr
+
+    with open(os.path.join(project_dir('minimal2_v1'),
+        'ansible/shipit_config/kubernetes/deployment_artifacts.yml'), 'r') as f:
+        converted = order_dict_or_list(yaml.load(f.read()))
+
+    with open(os.path.join(project_dir('minimal2_v1'), 'desired_k8s.yml')) as f:
+        desired = order_dict_or_list(yaml.load(f.read()))
+
+    assert converted == desired
+
+def test_shipit_save_config_openshift():
+    env = ScriptTestEnvironment()
+    result = env.run('ansible-container', 'shipit', 'openshift', '--save-config',
+                     cwd=project_dir('minimal2_v1'), expect_stderr=True)
+    assert "Saved configuration to" in result.stderr
+
+    with open(os.path.join(project_dir('minimal2_v1'),
+        'ansible/shipit_config/openshift/deployment_artifacts.yml'), 'r') as f:
+        converted = order_dict_or_list(yaml.load(f.read()))
+
+    with open(os.path.join(project_dir('minimal2_v1'), 'desired_oc.yml')) as f:
+        desired = order_dict_or_list(yaml.load(f.read()))
+
+        assert converted == desired
 
 #def test_shipit_minimal_docker_container():
 #    env = ScriptTestEnvironment()

--- a/test/local/ansible/container.yml
+++ b/test/local/ansible/container.yml
@@ -5,6 +5,7 @@ services:
     volumes:
        - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}" 
        - /var/run/docker.sock:/var/run/docker.sock
+       - /tmp/:/tmp/
     working_dir: "${ANSIBLE_CONTAINER_PATH}" 
     environment:
       - VIRTUAL_ENV=/usr/local  


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY
- Added another layer on top of the builder container by adding the kompose binary, which is now used to generate Kubernetes and OpenShift artifacts when `ansible-container shipit x --save-config` is run.
- First the directory in which the parsed container.yml is stored is mounted inside the builder container, and then `kompose` does the conversion and spits out the artifacts.

TODO:
- [x] Add check if the builder image with the kompose tag is present or not, if not then pull it.
- [x] Add tests
## 

Unblocks #219, Fixes #233 
