### PR TITLE
A bunch of fixes in final image metadata

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -524,9 +524,13 @@ class Engine(BaseEngine):
         cmd = self.config['services'][host].get('command', '')
         if isinstance(cmd, list):
             cmd = json.dumps(cmd)
+        entrypoint = self.config['services'][host].get('entrypoint', '')
+        if isinstance(entrypoint, list):
+            entrypoint = json.dumps(entrypoint)
         image_config = dict(
             USER=self.config['services'][host].get('user', 'root'),
             WORKDIR=self.config['services'][host].get('working_dir', '/'),
+            ENTRYPOINT=entrypoint,
             CMD=cmd
         )
         if flatten:

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -522,8 +522,8 @@ class Engine(BaseEngine):
             self.project_name, host, client
         )
         cmd = self.config['services'][host].get('command', '')
-        if isinstance(self.config['services'][host].get('command'), list):
-            cmd = ' '.join(self.config['services'][host]['command'])
+        if isinstance(cmd, list):
+            cmd = json.dumps(cmd)
         image_config = dict(
             USER=self.config['services'][host].get('user', 'root'),
             WORKDIR=self.config['services'][host].get('working_dir', '/'),

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -530,6 +530,7 @@ class Engine(BaseEngine):
         image_config = dict(
             USER=self.config['services'][host].get('user', 'root'),
             WORKDIR=self.config['services'][host].get('working_dir', '/'),
+            LABEL='com.docker.compose.oneoff="" com.docker.compose.project="%s"' % self.project_name,
             ENTRYPOINT=entrypoint,
             CMD=cmd
         )


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
The issues fixed by this pull request (as a single PR, as they all touch the same code) are:

 - images may not have a custom entrypoint specified (it is ignored)
 - images may not have a command specified as a list (only as a string that gets passed to the shell)
 - images have labels left over from `docker-compose` which means containers created from them get destroyed at every `ansible-composer` run