### PR TITLE
builder: add symlink to ease transition

### DIFF
--- a/container/templates/ansible-dockerfile.j2
+++ b/container/templates/ansible-dockerfile.j2
@@ -15,3 +15,8 @@ ADD builder.sh /usr/local/bin/builder.sh
 ADD wait_on_host.py /usr/local/bin/wait_on_host.py
 ADD ansible-container-inventory.py /etc/ansible/ansible-container-inventory.py
 ADD ansible.cfg /etc/ansible/ansible.cfg
+
+# In 9deb3eb we moved to /usr/bin/ansible-playbook
+# Let's ease the transition on people using <9deb3eb code
+# by symlinking to the new place
+RUN ln -s /usr/bin/ansible-playbook /usr/local/bin/ansible-playbook


### PR DESCRIPTION
In 9deb3eb we moved to /usr/bin/ansible-playbook
Let's ease the transition on people using <9deb3eb code
by symlinking to the new place