### PR TITLE
 Allow to override the default timeout used for slow integration tests

### DIFF
--- a/test/utils/tests/integration.sh
+++ b/test/utils/tests/integration.sh
@@ -16,7 +16,7 @@ export COVERAGE_FILE="${test_dir}/data/coverage"
 cd "${source_root}"
 
 PYTHONDONTWRITEBYTECODE=1 PATH="${source_root}/test/utils/coverage:$PATH" py.test \
-    --timeout=30 \
+    --timeout=120 \
     --verbose --strict -r a --junit-xml="${test_dir}/junit.xml" "${source_root}/test/integration"
 
 coverage combine


### PR DESCRIPTION
On my laptop, I was unable to run the slow integration test suite due to the value of the default timeout (30 seconds).

This pull request allows to override this timeout using the `AC_SLOW_TEST_TIMEOUT` environment variable is used (without modifying the local repository). 

I have synchronized/updated both [CONTRIBUTORS.md](https://github.com/ansible/ansible-container/blob/5869146e2e3bf44431a1bb2c10dcb7a541125750/CONTRIBUTORS.md#running-tests) and [test/README.md](https://github.com/ansible/ansible-container/blob/5869146e2e3bf44431a1bb2c10dcb7a541125750/test/README.md) (see https://github.com/ansible/ansible-container/commit/aa7b86722eb257b30ac7468eb724079e9487e10b), let me know if you prefer:
* keep `CONTRIBUTORS.md` only and remove `test/README.md`
* keep `test/README.md` and update `CONTRIBUTORS.md` adding a pointer to `test/README.md` and removing duplicated content
 * otherwise