### PR TITLE
Add pre-commit script and update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,22 +3,26 @@ Ansible Container has been contribued to by the following authors:
 
 Chris Houseknecht <chouseknecht@ansible.com>
 Joshua "jag" Ginsberg <jag@flowtheory.net>
-Matt Clay <matt@mystile.com>
 Shubham Minglani <shubham@linux.com>
+Matt Clay <matt@mystile.com>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
+Dusty Mabe <dusty@dustymabe.com>
 Charlie Drage <charlie@charliedrage.com>
+Roderick Randolph <roderickrandolph@users.noreply.github.com>
 chouseknecht <chousek@redhat.com>
-Will Thames <wthames@redhat.com>
 Todd Barr <tbarr@ansible.com>
-Arnaud Moret <arnaud.moret@gmail.com>
-Daniel Heitmann <dictvm@horrendum.de>
+Will Thames <wthames@redhat.com>
+Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
+Daniel Heitmann <dictvm@horrendum.de>
+Arnaud Moret <arnaud.moret@gmail.com>
 Evan Zeimet <evan.zeimet@cdw.com>
-Gerard Braad <me@gbraad.nl>
-Sidharth Surana <ssurana@vmware.com>
-Andrea De Pirro <andrea.depirro@yameveo.com>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 Chrrrles Paul <chrrrles@users.noreply.github.com>
+Andrea De Pirro <andrea.depirro@yameveo.com>
+Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
+Gerard Braad <me@gbraad.nl>
+Sidharth Surana <ssurana@vmware.com>

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# Copy this script to .git/hooks/pre-commit
+#
+
+python update-authors.py > AUTHORS
+git add AUTHORS


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY

Add pre-commit script. Contributors can copy to .git/hooks/pre-commit, and it will automatically update AUTHORS.