### PR TITLE
Keep info related to tests in test/README.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,25 +42,7 @@ Please observe the following when submitting a PR:
 
 ### Running tests
 
-Unit and integration tests are found in the [test subdirectory](./test). When a pull request is submitted, tests are automatically executed on
-Travis to test the submitted code.
-
-Running tests locally requires cloning the Ansible Container repo, and setting up your environment to run from source. See the [Installation 
-Guide](https://docs.ansible.com/ansible-container/installation.html) for assistance. 
-
-Test execution is initiated by running the [test/run.sh](./test/run.sh) script found in your local copy of Ansible Container. For example:
-
-```
-$ cd ansible-container
-$ ./test/run.sh 
-```
-
-If the *local-test* image does not exist, the script will create it by running `ansible-container build` within the [test/local project](./test/local). 
-Once the image is available, tests are executed within a container via `ansible-container run`. Subsequent runs of the script will use the existing 
-*local-test* image and skip the build step. 
-
-Test execution occurs exactly the same way on Travis as it does in a local development environment. So if tests run successfully in your local 
-environment, they *should* run successfully on Travis.
+See  [test/README.md](./test/README.md)
 
 ## Provide examples
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,19 +1,23 @@
 ## Running tests
 
-Unit and integration tests live here. Running tests locally requires having ansible-container installed. Execute tests from within 
-the local copy of the ansible-container repo by running *test/run.sh*:
+Unit and integration tests live here. When a pull request is submitted, tests are automatically executed on Travis to test the submitted code.
+
+Running tests locally requires cloning the Ansible Container repo, and setting up your environment to run from source. See the [Installation
+ Guide](https://docs.ansible.com/ansible-container/installation.html) for assistance.
+
+Test execution is initiated by running the [test/run.sh](./run.sh) script found in your local copy of Ansible Container. For example:
 
 ```
 $ cd ansible-container
-$ ./test/run.sh 
+$ ./test/run.sh
 ```
 
-If the local-test image does not exist, the script will create it using `ansible-container build` against the *test/local* project. Once the image
-is availabe tests are executed within a container via `ansible-container run`. Subsequent runs of the script will use the existing local-test image 
-to mount the local copy of ansible-container and execute tests.
+If the *local-test* image does not exist, the script will create it by running `ansible-container build` within the [test/local project](./local).
+Once the image is available, tests are executed within a container via `ansible-container run`. Subsequent runs of the script will use the existing
+*local-test* image and skip the build step.
 
-This is the same script and test execution that occurs on Travis. So, if tests run successfully in your local environment, they *should* run 
-successfully on Travis. 
+Test execution occurs exactly the same way on Travis as it does in a local development environment. So if tests run successfully in your local
+environment, they *should* run successfully on Travis.
 
 Thanks for trying out Ansible Container!
 


### PR DESCRIPTION
The content of [test/README.md](https://github.com/ansible/ansible-container/blob/5869146e2e3bf44431a1bb2c10dcb7a541125750/test/README.md) was duplicated in [CONTRIBUTORS.md](https://github.com/ansible/ansible-container/blob/5869146e2e3bf44431a1bb2c10dcb7a541125750/CONTRIBUTORS.md#running-tests) but since https://github.com/ansible/ansible-container/commit/aa7b86722eb257b30ac7468eb724079e9487e10b, content has diverged.

This pull request move the up-to-date documentation related to tests in `test` directory.