### PR TITLE
Complete requirements.yml

### DIFF
--- a/container/templates/ac_galaxy.py
+++ b/container/templates/ac_galaxy.py
@@ -180,11 +180,19 @@ def update_requirements_yml(role_obj):
     if not requirements:
         requirements = []
     for req in requirements:
-        if req.get('src', '') == role_obj.name:
+        if req.get('src', '') == role_obj.src:
             logger.warning('Requirement %s already found in requirements.yml',
                            role_obj.name)
             return
-    requirements.append({'src': role_obj.name})
+    role_def = {}
+    role_def[u'src'] = role_obj.src
+    if role_obj.version and role_obj.vesion != 'master':
+        role_def[u'version'] = role_obj.version
+    if role_obj.scm:
+        role_def[u'scm'] = role_obj.scm
+    if role_obj.name and role_obj.name != role_obj.src:
+        role_def[u'name'] = role_obj.name
+    requirements.append(role_def)
     try:
         ruamel.yaml.round_trip_dump(requirements,
                                     stream=open(requirements_yml_path, 'w'))

--- a/docs/rst/roles/access.rst
+++ b/docs/rst/roles/access.rst
@@ -31,13 +31,13 @@ locally, then the following will execute the role as part of ``main.yml``:
 
 .. note::
 
-    If using Docker Machine, be aware that mounting paths outside fo the user's home directory to a container may
+    If using Docker Machine, be aware that mounting paths outside of the user's home directory to a container may
     require additional steps. For more details see the Docker tutorial, `Manage data in containers <https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume>`_.
 
 .. note::
 
     If you choose to access locally installed roles using ``--roles-path``, then you must include the ``--roles-path``
-    optioin when running the ``run``, ``push`` and ``shipit`` commands. During these operations the ``main.yml`` playbook is
+    option when running the ``run``, ``push`` and ``shipit`` commands. During these operations the ``main.yml`` playbook is
     accessed using the ``--list-hosts`` option to determine the list of hosts affected by the playbook. If roles cannot be
     accessed, Ansible Playbook will fail to parse ``main.yml``.
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
This relates to the role testing issue (#271). In order to test a role it has to go through the install process, which means downloading it from GitHub, even though the role already exists on the local file system. The role has to be downloaded and applied to the local *ansible* project, updating `container.yml`, `main.yml` and `requirements.yml`.

To invoke the download we pass a commit hash as the version. The install sees the hash and works, however the hash does not get added to the new `requirements.yml` entry. This PR fixes this by adding scm, src, version and name attributes to the entry. Only attributes containing a value are added.