### PR TITLE
Make warning regarding non-container roles more explicit and clear.

### DIFF
--- a/container/templates/ac_galaxy.py
+++ b/container/templates/ac_galaxy.py
@@ -224,8 +224,8 @@ def install(roles):
                         if service:
                             update_main_yml(service, role_obj)
                         else:
-                            logger.warning('Role %s is not Ansible Container enabled.',
-                                           role_obj)
+                            logger.warning("WARNING: %s is not Container Enabled but will still be added to "
+                                           "requirements.yml", role_obj.name)
                         update_requirements_yml(role_obj)
                     roles_processed.append(role_to_install)
                 except FatalException:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
When a role that is not *container enabled* is encountered by ac_galaxy a warning is thrown. The current warning actually has a bug in it, as it passes the role object into the format rather than the role's name attribute resulting in a message that looks like this: "Role <ansible.galaxy.role.GalaxyRole object at 0x7f386ab6aed0> is not Ansible Container enabled"

This change fixes the format bug, and alters the text to makes it clear that even though the role is NOT container enabled, it will still be added to *requirements.yml*. Previously it was unclear if any action was taken with the role, and you were left wondering if perhaps it was skipped altogether.