### PR TITLE
Allow to run test suite using tox

### DIFF
--- a/test/local/ansible/container.yml
+++ b/test/local/ansible/container.yml
@@ -1,7 +1,7 @@
 version: "1"
 services:
-  test:
-    image: python:2.7
+  test-{{ python_version }}:
+    image: "python:{{ python_version }}"
     volumes:
        - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}" 
        - /var/run/docker.sock:/var/run/docker.sock

--- a/test/local/ansible/main.yml
+++ b/test/local/ansible/main.yml
@@ -1,4 +1,4 @@
-- hosts: test 
+- hosts: test*
   gather_facts: no
   vars:
     project_path: "{{ lookup('env','ANSIBLE_CONTAINER_PATH') }}"

--- a/test/run.sh
+++ b/test/run.sh
@@ -9,11 +9,12 @@
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '..')))")
 export ANSIBLE_CONTAINER_PATH=${source_root}
 
-image_exists=$(docker images local-test:latest | wc -l)
+export AC_PYTHON_VERSION=$(python -c "import platform; print('.'.join(platform.python_version_tuple()[0:2]))")
+image_exists=$(docker images local-test-"${AC_PYTHON_VERSION}":latest | wc -l)
 if [ "${image_exists}" -le 1 ]; then
    ansible-container --project "${source_root}/test/local" --debug build --local-builder --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
 fi
 
 ansible-container --project "${source_root}/test/local" --debug run
-status=$(docker inspect --format="{{ .State.ExitCode }}" ansible_test_1)
+status=$(docker inspect --format="{{ .State.ExitCode }}" ansible_test-"${AC_PYTHON_VERSION}"_1)
 exit "${status}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py34,py35
+
+[testenv]
+usedevelop = True
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test/requirements.txt
+commands =
+    {toxinidir}/test/run.sh


### PR DESCRIPTION
This allow to execute the test suite locally using tox.

Once compatibility with Python 3 has been fixed, Python 3 could be added to `.travis.yml` too.
