### PR TITLE
Python 3 compat: handle new behavior of argparse

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -193,6 +193,7 @@ def commandline():
                              u'Jinja2 templating in container.yml.', default=None)
 
     subparsers = parser.add_subparsers(title='subcommand', dest='subcommand')
+    subparsers.required = True
     for subcommand in AVAILABLE_COMMANDS:
         logger.debug('Registering subcommand %s', subcommand)
         subparser = subparsers.add_parser(subcommand, help=AVAILABLE_COMMANDS[subcommand])

--- a/test/integration/test_fast.py
+++ b/test/integration/test_fast.py
@@ -14,7 +14,8 @@ def test_no_command_shows_help():
     result = env.run('ansible-container', expect_error=True)
     assert result.returncode == 2
     assert len(result.stdout) == 0
-    assert "ansible-container: error: too few arguments" in result.stderr
+    assert "usage: ansible-container" in result.stderr
+    assert "ansible-container: error:" in result.stderr
 
 
 def test_help_command_shows_help():


### PR DESCRIPTION
Using Python 3, the `test_no_command_shows_help` test fails due to the updated behavior of `argparse` module. The `parser.parse_args()` doesn't raise an error when a command isn't provided. See https://bugs.python.org/issue9253.

```
     def test_no_command_shows_help():
         env = ScriptTestEnvironment()
         result = env.run('ansible-container', expect_error=True)
 >       assert result.returncode == 2
 E       assert 1 == 2
 E        +  where 1 = <scripttest.ProcResult object at 0x7f9807e44438>.returncode
```
