### PR TITLE
Ensure all_hosts_in_orchestration return a list

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -55,7 +55,8 @@ class Engine(BaseEngine):
 
         :return: list of strings
         """
-        return (self.config.get('services') or {}).keys()
+        services = self.config.get('services')
+        return list(services.keys()) if services else []
 
     def hosts_touched_by_playbook(self):
         """


### PR DESCRIPTION
Using Python 3, `all_hosts_in_orchestration` method returns a `dict_keys` instead of a list, the following error occurs:

> TypeError: can only concatenate list (not "dict_keys") to list
