### PR TITLE
Python 3 compat: use 'as' instead of comma after 'except' keyword

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -211,15 +211,15 @@ def commandline():
 
     try:
         getattr(engine, u'cmdrun_{}'.format(args.subcommand))(**vars(args))
-    except exceptions.AnsibleContainerAlreadyInitializedException, e:
+    except exceptions.AnsibleContainerAlreadyInitializedException as e:
         logger.error('Ansible Container is already initialized')
         sys.exit(1)
-    except exceptions.AnsibleContainerNotInitializedException, e:
+    except exceptions.AnsibleContainerNotInitializedException as e:
         logger.error('No Ansible Container project data found - do you need to '
                      'run "ansible-container init"?')
         sys.exit(1)
-    except exceptions.AnsibleContainerNoAuthenticationProvidedException, e:
-        logger.error(unicode(e))
+    except exceptions.AnsibleContainerNoAuthenticationProvidedException as e:
+        logger.exception(e)
         sys.exit(1)
     except exceptions.AnsibleContainerNoMatchingHosts:
         logger.error('No matching service found in ansible/container.yml')
@@ -227,7 +227,7 @@ def commandline():
     except exceptions.AnsibleContainerHostNotTouchedByPlaybook:
         logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.')
         sys.exit(1)
-    except Exception, e:
+    except Exception as e:
         if args.debug:
             logger.exception(e)
         else:

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -422,7 +422,7 @@ class Engine(BaseEngine):
                                             volume.replace('/', '_'))
                 try:
                     client.inspect_volume(name=volume_name)
-                except docker_errors.NotFound, e:
+                except docker_errors.NotFound as e:
                     # We need to create this volume
                     client.create_volume(name=volume_name, driver='local')
                 service_config['volumes'].remove(volume)

--- a/container/engine.py
+++ b/container/engine.py
@@ -293,7 +293,7 @@ def cmdrun_init(base_path, project=None, **kwargs):
                                 headers={'Accepts': 'application/json'})
         try:
             response.raise_for_status()
-        except requests.RequestException, e:
+        except requests.RequestException as e:
             raise requests.RequestException(u'Could not find %r on Galaxy '
                                             u'server %r: %r' % (project,
                                                                 galaxy_base_url,
@@ -314,7 +314,7 @@ def cmdrun_init(base_path, project=None, **kwargs):
         archive = requests.get(archive_url)
         try:
             archive.raise_for_status()
-        except requests.RequestException, e:
+        except requests.RequestException as e:
             raise requests.RequestException(u'Could not get archive at '
                                             u'%r: %r' % (archive_url, e))
         faux_file = io.BytesIO(archive.content)

--- a/container/templates/ac_galaxy.py
+++ b/container/templates/ac_galaxy.py
@@ -154,7 +154,7 @@ def update_main_yml(service, role_obj):
         raise FatalException()
 
     if not main_yml:
-        main_yml = [] 
+        main_yml = []
 
     # For readability, put the role name at the start of the dict
     defaults.insert(0, 'role', role_obj.name)

--- a/container/templates/ac_galaxy.py
+++ b/container/templates/ac_galaxy.py
@@ -37,7 +37,7 @@ class MakeTempDir(object):
         try:
             logger.debug('Cleaning up temporary directory %s...', self.temp_dir)
             shutil.rmtree(self.temp_dir)
-        except Exception, e:
+        except Exception:
             logger.exception('Failure cleaning up temp space')
             pass
 
@@ -82,7 +82,7 @@ def get_container_yml_snippet(role_obj):
     if os.path.exists(container_yml_path):
         try:
             snippet = ruamel.yaml.round_trip_load(open(container_yml_path))
-        except Exception, e:
+        except Exception:
             logger.exception('Error loading container.yml snippet for %s',
                              role_obj)
             return None
@@ -118,7 +118,7 @@ def update_container_yml(role_obj):
                                       'container.yml')
     try:
         container_yml = ruamel.yaml.round_trip_load(open(container_yml_path))
-    except Exception, e:
+    except Exception:
         logger.exception('Could not load project ansible/container.yml')
         raise FatalException()
 
@@ -137,7 +137,7 @@ def update_container_yml(role_obj):
     try:
         ruamel.yaml.round_trip_dump(container_yml,
                                     stream=open(container_yml_path, 'w'))
-    except Exception, e:
+    except Exception:
         logger.exception('Error updating ansible/container.yml')
         raise FatalException()
     return new_service_key
@@ -149,7 +149,7 @@ def update_main_yml(service, role_obj):
     main_yml = None
     try:
         main_yml = ruamel.yaml.round_trip_load(open(main_yml_path))
-    except Exception, e:
+    except Exception:
         logger.exception('Could not load project ansible/main.yml')
         raise FatalException()
 
@@ -167,7 +167,7 @@ def update_main_yml(service, role_obj):
     try:
         ruamel.yaml.round_trip_dump(main_yml,
                                     stream=open(main_yml_path, 'w'))
-    except Exception, e:
+    except Exception:
         logger.exception('Error updating ansible/main.yml')
         raise FatalException()
 
@@ -178,7 +178,7 @@ def update_requirements_yml(role_obj):
     if os.path.exists(requirements_yml_path):
         try:
             requirements = ruamel.yaml.round_trip_load(open(requirements_yml_path)) or []
-        except Exception, e:
+        except Exception:
             logger.exception('Could not load project ansible/requirements.yml')
             raise FatalException()
     if not requirements:
@@ -200,7 +200,7 @@ def update_requirements_yml(role_obj):
     try:
         ruamel.yaml.round_trip_dump(requirements,
                                     stream=open(requirements_yml_path, 'w'))
-    except Exception, e:
+    except Exception:
         logger.exception('Error updating ansible/requirements.yml')
         raise FatalException()
 
@@ -246,7 +246,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         install(args.roles)
-    except Exception, e:
+    except Exception as e:
         logger.error(repr(e))
         sys.exit(1)
 


### PR DESCRIPTION
Fix python 3 compat, see PEP 3110.
