### PR TITLE
Don't ignore failures of ansible-container commands

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -6,6 +6,9 @@
 # on Travis.
 #
 #
+
+set -o nounset -o errexit
+
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '..')))")
 export ANSIBLE_CONTAINER_PATH=${source_root}
 


### PR DESCRIPTION
Exit status of `test/run.sh` should not be 0 when an `ansible-container` command fails.
`nounset` is an added bonus.
