### PR TITLE
Python 3 compat: unit tests

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -9,6 +9,7 @@ import os
 import json
 import yaml
 import re
+import six
 
 from jinja2 import Environment, FileSystemLoader
 from collections import Mapping
@@ -91,7 +92,10 @@ class AnsibleContainerConfig(Mapping):
         j2_env.globals['lookup'] = self._lookup
         j2_env.filters.update(self.all_filters)
         j2_tmpl = j2_env.get_template(template)
-        return j2_tmpl.render(**context).encode('utf8')
+        tmpl = j2_tmpl.render(**context)
+        if isinstance(tmpl, six.binary_type):
+            tmpl = tmpl.encode('utf8')
+        return tmpl
 
     def _get_variables(self):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ docker-py==1.8.0
 Jinja2==2.8
 PyYAML==3.11
 requests==2.7.0
+six


### PR DESCRIPTION
Using Python 3, one unit test fails:

```
 =========================== short test summary info ============================
 FAIL test/unit/container/test_config.py::TestAnsibleContainerConfig::test_should_parse_json_file
 =================================== FAILURES ===================================
 ____________ TestAnsibleContainerConfig.test_should_parse_json_file ____________
[...]
             try:
                 config = json.loads(data)
             except Exception as exc:
 >               raise AnsibleContainerConfigException(u"JSON exception: %s" % str(exc))
 E               container.exceptions.AnsibleContainerConfigException: JSON exception: the JSON object must be str, not 'bytes'

 container/config.py:208: AnsibleContainerConfigException
```
