### PR TITLE
Fix port comparison error in deployment module

### DIFF
--- a/container/shipit/kubernetes/deployment.py
+++ b/container/shipit/kubernetes/deployment.py
@@ -363,7 +363,10 @@ class Deployment(object):
     def _port_exists(port, ports):
         found = False
         for p in ports:
-            if p['containerPort'] == int(port):
+            if isinstance(p, dict) and p.get('containerPort') == int(port):
+                found = True
+                break
+            elif isinstance(p, int) and p == int(port):
                 found = True
                 break
         return found

--- a/container/shipit/openshift/deployment.py
+++ b/container/shipit/openshift/deployment.py
@@ -364,7 +364,10 @@ class Deployment(object):
     def _port_exists(port, ports):
         found = False
         for p in ports:
-            if p['containerPort'] == int(port):
+            if isinstance(p, dict) and p.get('containerPort') == int(port):
+                found = True
+                break
+            elif isinstance(p, int) and p == int(port):
                 found = True
                 break
         return found


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Fixes #253 and replaces #277.

When building configuration files the each port in the ports list is a dict, otherwise it is an int. Thus when looking for an existing port we need to take into account the list element's type. Applies to both *kube* and *openshift*.