### PR TITLE
Use tox and pyenv inside the test container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ sftp-config.json
 
 venv/
 *.retry
+.python-version
 
 * Vagrant things
 .vagrant/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 Ansible Container has been contribued to by the following authors:
-(This list is automatically generated - please file an issue for corrections)
+This list is automatically generated - please file an issue for corrections)
 
 Chris Houseknecht <chouseknecht@ansible.com>
 Joshua "jag" Ginsberg <jag@ansible.com>
@@ -7,6 +7,7 @@ Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
+Pilou <pilou-@users.noreply.github.com>
 Dusty Mabe <dusty@dustymabe.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Charlie Drage <charlie@charliedrage.com>

--- a/test/build-test-img/README.md
+++ b/test/build-test-img/README.md
@@ -1,0 +1,19 @@
+# build-test-img
+
+Project for building the *ansible/ansble-container-testing* image. When you're ready to create a new version of the image, build the project tag the image, and push it to Docker Hub.
+
+You'll of course need to log into Docker Hub using the `docker login` command, and then run the following to build and push the image:
+
+```
+# Set the workind directory to build-test-img
+$ cd test/build-test-img
+
+# Execute the run.sh script to build the image
+$ ./run.sh 
+
+# Tag the image
+$ docker tag build-test-img-test:latest ansible/ansible-container-testing:latest
+
+# And push it to Docker Hub 
+$ docker push ansible/ansible-container-testing:latest
+```

--- a/test/build-test-img/ansible/container.yml
+++ b/test/build-test-img/ansible/container.yml
@@ -1,0 +1,11 @@
+version: "1"
+services:
+  test:
+    image: "centos:7"
+    environment:
+    - PYTHON_VERSIONS=2.7.12 3.4.5 3.5.0
+    volumes:
+    - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}"
+    working_dir: "${ANSIBLE_CONTAINER_PATH}" 
+    
+registries: {}

--- a/test/build-test-img/ansible/main.yml
+++ b/test/build-test-img/ansible/main.yml
@@ -1,0 +1,75 @@
+- hosts: test
+  gather_facts: no
+  vars:
+    project_path: "{{ lookup('env','ANSIBLE_CONTAINER_PATH') }}"
+
+  tasks:
+
+  - name: Install epel
+    yum:
+      name: epel-release
+      state: present
+
+  - name: Install docker 1.11.2
+    yum:
+      name: "{{ item }}"
+      state: present
+    with_items:
+    - https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-1.11.2-1.el7.centos.noarch.rpm
+    - https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.11.2-1.el7.centos.x86_64.rpm
+
+  - name: Install yum packages
+    yum:
+      name: "{{ item }}"
+      state: latest
+    with_items:
+    - "@Development tools"
+    - git
+    - python-setuptools
+    - python-devel
+    - python-pip
+    - cabal-install
+    - openssl
+    - openssl-devel
+    - make
+    - bzip2-devel
+    - readline-devel
+    - sqlite-devel
+    - patch
+
+  - name: Upgrade setup tools
+    pip:
+      state: latest
+      name: setuptools
+
+  - name: Install Python requirements for testing
+    pip:
+      requirements: "{{ project_path }}/test/requirements.txt"
+      state: present
+
+  - name: Update cabal
+    command: cabal update
+
+  - name: Install cabal library
+    command: cabal install Cabal
+
+  - name: Install shellcheck
+    command: cabal install shellcheck
+
+  - name: Clone pyenv
+    git:
+      repo: https://github.com/yyuu/pyenv.git
+      dest: /pyenv
+
+  - name: Copy pyinstall script
+    template:
+      src: pyinstall.sh.j2
+      dest: /usr/bin/pyinstall.sh
+      owner: root
+      group: root
+      mode: 0775
+
+  - name: Run pyinstall
+    command: /usr/bin/pyinstall.sh
+
+

--- a/test/build-test-img/ansible/requirements.txt
+++ b/test/build-test-img/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.8.0

--- a/test/build-test-img/ansible/requirements.yml
+++ b/test/build-test-img/ansible/requirements.yml
@@ -1,0 +1,5 @@
+# Install Ansible Roles
+# ---------------------
+# When the build process starts `ansible-galaxy install -r requirements.yml` is executed
+# using this file. Follow the instructions at http://docs.ansible.com/ansible/galaxy.html
+# to include any roles you want intalled prior to running main.yml.

--- a/test/build-test-img/ansible/templates/pyinstall.sh.j2
+++ b/test/build-test-img/ansible/templates/pyinstall.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+PYENV_ROOT=/pyenv; export PYENV_ROOT
+PATH=${PYENV_ROOT}/bin:${PATH}; export PATH
+
+eval $(pyenv init -)
+
+for pyver in ${PYTHON_VERSIONS[@]}
+do
+    pyenv install ${pyver}
+done

--- a/test/build-test-img/run.sh
+++ b/test/build-test-img/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../..')))")
+export ANSIBLE_CONTAINER_PATH=${source_root}
+
+ansible-container --debug build --local-builder --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"

--- a/test/local/ansible/container.yml
+++ b/test/local/ansible/container.yml
@@ -1,15 +1,16 @@
 version: "1"
 services:
   test:
-    image: python:2.7
+    image: "ansible/ansible-container-testing:latest"
     volumes:
-       - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}" 
-       - /var/run/docker.sock:/var/run/docker.sock
+      - "${ANSIBLE_CONTAINER_PATH}:${ANSIBLE_CONTAINER_PATH}"
+      - /var/run/docker.sock:/var/run/docker.sock
     working_dir: "${ANSIBLE_CONTAINER_PATH}" 
     environment:
-      - VIRTUAL_ENV=/usr/local  
-      - DOCKER_API_VERSION
+    - PYTHON_VERSIONS=2.7.12 3.4.5 3.5.0
+    entrypoint:
+      - /usr/bin/entrypoint.sh
     command:
-      - ./test/utils/run_tests.sh
+      - tox
 
 registries: {}

--- a/test/local/ansible/main.yml
+++ b/test/local/ansible/main.yml
@@ -2,50 +2,18 @@
   gather_facts: no
   vars:
     project_path: "{{ lookup('env','ANSIBLE_CONTAINER_PATH') }}"
+
   tasks:
-    - name: Update apt cache
-      apt: update_cache=yes
 
-    - name: Install https transport
-      apt: name="{{ item }}"
-      with_items:
-        - apt-transport-https
-        - ca-certificates
+  - name: Install ansible-container from source
+    command: python ./setup.py develop
+    args:
+      chdir: "{{ project_path }}"
 
-    - name: Add apt key 
-      command: apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-
-    - name: Touch docker.list
-      file: name=/etc/apt/sources.list.d/docker.list state=touch
-
-    - name: Add repo to docker.list
-      lineinfile:
-        dest: /etc/apt/sources.list.d/docker.list
-        line: "deb https://apt.dockerproject.org/repo debian-jessie main"
-
-    - name: Update cache again
-      apt: update_cache=yes
-
-    - name: Install apt packages 
-      apt: name="{{ item }}"
-      with_items:
-        - docker-engine=1.11.2-0~jessie
-        - shellcheck
-
-    - name: Install python packages 
-      pip: name="{{ item }}"
-      with_items:
-        - pytest
-        - pytest-timeout
-        - pytest-cov
-        - markupsafe
-        - docker-compose
-        - scripttest
-
-    - name: Install python requirements
-      pip: requirements="{{ project_path }}/requirements.txt"
-
-    - name: Install ansible-container from source
-      command: python ./setup.py develop
-      args:
-        chdir: "{{ project_path }}" 
+  - name: Copy entrypoint script
+    template:
+      src: entrypoint.sh.j2
+      dest: /usr/bin/entrypoint.sh
+      owner: root
+      group: root
+      mode: 0775

--- a/test/local/ansible/templates/entrypoint.sh.j2
+++ b/test/local/ansible/templates/entrypoint.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+
+PYENV_ROOT=/pyenv; export PYENV_ROOT
+PATH=${PYENV_ROOT}/bin:${PATH}; export PATH
+
+# Make sure we can access shellcheck
+PATH=${PATH}:/root/.cabal/bin; export PATH
+
+eval $(pyenv init -)
+
+# Set the .python-version file
+pyenv local ${PYTHON_VERSIONS[@]}
+
+exec "$@"

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,8 @@ coverage
 pytest-cov
 pytest-timeout
 scripttest
+pytest
+markupsafe
+tox
+tox-pyenv
+virtualenv

--- a/test/run.sh
+++ b/test/run.sh
@@ -12,9 +12,13 @@ set -o nounset -o errexit
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '..')))")
 export ANSIBLE_CONTAINER_PATH=${source_root}
 
+docker_version=$(docker version --format '{{json .}}' | python -c "import sys, json; print json.load(sys.stdin)['Server']['ApiVersion']")
+: "${DOCKER_API_VERSION:=$docker_version}"
+
 image_exists=$(docker images local-test:latest | wc -l)
 if [ "${image_exists}" -le 1 ]; then
-   ansible-container --project "${source_root}/test/local" --debug build --local-builder --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
+   ansible-container --project "${source_root}/test/local" --debug build --local-builder \
+     --with-variables ANSIBLE_CONTAINER_PATH="${source_root}"
 fi
 
 ansible-container --project "${source_root}/test/local" --debug run

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+#envlist = py27,py34,py35
+envlist = py27
+toxworkdir = /tmp
+
+[testenv]
+usedevelop = True
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test/requirements.txt
+commands =
+    {toxinidir}/test/utils/run_tests.sh


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY

Use *tox* inside the testing container and test with Python 2.7, 3.4, and 3.5. 

- created a Centos 7 base image with all the needed packages, shellcheck, pyenv and Python 2.7.12, 3.4.5, and 3.5.0. The image is on Docker Hub as ansible/ansible-container-testing. 
- added test/build-test-img project to use for rebuilding the image
- tests are executed the same as before by running ./test/run.sh
- the same script and process is used locally and in Travis

Current py34 and py35 are commented out in *tox.ini* because there are still syntax issues that need to be fixed. However, py27 completes the tests successfully.
