### PR TITLE
Fix OpenShift route state.

### DIFF
--- a/container/shipit/openshift/route.py
+++ b/container/shipit/openshift/route.py
@@ -91,8 +91,7 @@ class Route(object):
                     if hostname:
                         template['oso_route']['host'] = hostname
 
-                    if state != 'present':
-                        template['oso_route'] = state
+                    template['oso_route']['state'] = state
 
                 templates.append(template)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY

When creating the shipit role and `options: openshift: state` was set to`absent`, the route config was garbled. This PR fixes it.