### PR TITLE
run pip on ./requirements.txt

### DIFF
--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-test '(! -f /src/requirements.txt)' || pip install --no-cache-dir -q -U -r /src/requirements.txt
+if [ -s "./requirements.txt" ]; then
+    pip install --no-cache-dir -q -U -r ./requirements.txt
+fi
 
 if [ -f "./requirements.yml" ]; then
     roles=$(python -c "import yaml; roles = yaml.load(open('./requirements.yml', 'r')); print 0 if not roles else len(roles)")


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Configuration file `requirements.txt` was not being run by builder.sh.

Changed the shell test to also match the `requirements.yml` code.

Fixes #306 


Run pip on ./requirements.txt.

Match the test format for the rest of the file, and use the same path as the requirements.yml stanza.