### PR TITLE
Use Docker 1.12 to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
   - sudo apt-get update -qq
   - sudo apt-get install -y shellcheck
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine=1.11.2-0~trusty
+  # - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine=1.11.2-0~trusty
 
 install:
   - pip install -r requirements.txt -r test/requirements.txt

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,8 +5,8 @@ Chris Houseknecht <chouseknecht@ansible.com>
 Joshua "jag" Ginsberg <jag@ansible.com>
 Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
-Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
+Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
 Charlie Drage <charlie@charliedrage.com>
@@ -17,6 +17,7 @@ Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
 Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
+Sean Summers <ssummer3@nd.edu>
 Evan Zeimet <evan.zeimet@cdw.com>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 Chrrrles Paul <chrrrles@users.noreply.github.com>

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -532,11 +532,14 @@ class Engine(BaseEngine):
             entrypoint = json.dumps(entrypoint)
         image_config = dict(
             USER=self.config['services'][host].get('user', 'root'),
-            WORKDIR=self.config['services'][host].get('working_dir', '/'),
             LABEL='com.docker.compose.oneoff="" com.docker.compose.project="%s"' % self.project_name,
             ENTRYPOINT=entrypoint,
             CMD=cmd
         )
+        # Only add WORKDIR if it does not contain an unexpanded environment var
+        workdir = self.config['services'][host].get('working_dir', '/')
+        image_config['WORKDIR'] = workdir if not re.search('\$|\{', workdir) else '/' 
+
         if flatten:
             logger.info('Flattening image...')
             exported = client.export(container_id)

--- a/container/templates/builder.sh
+++ b/container/templates/builder.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [ -s "./requirements.txt" ]; then
+    echo "Running pip install of ansible/requirements.txt" 
     pip install --no-cache-dir -q -U -r ./requirements.txt
 fi
 

--- a/test/local/ansible/requirements.txt
+++ b/test/local/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.8.0


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- Remove docker 1.11.2 downgrade in .travis.yml. By default 1.12.0 gets installed.
- Fixes #310 