### PR TITLE
Use DOCKER_CLIENT_TIMEOUT env var when instantiating Docker client

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
+Dylan Silva <thaumos@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
 Todd Barr <tbarr@ansible.com>
@@ -25,4 +26,5 @@ Andrea De Pirro <andrea.depirro@yameveo.com>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
 Gerard Braad <me@gbraad.nl>
+Trishna Guha <trishnaguha17@gmail.com>
 Sidharth Surana <ssurana@vmware.com>

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -16,6 +16,7 @@ import pprint
 import docker
 from docker.client import errors as docker_errors
 from docker.utils import kwargs_from_env
+from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from compose.cli.command import project_from_options
 from compose.cli import main
 from yaml import dump as yaml_dump
@@ -743,7 +744,8 @@ class Engine(BaseEngine):
         if not self._client:
             # To ensure version compatibility, we have to generate the kwargs ourselves
             client_kwargs = kwargs_from_env(assert_hostname=False)
-            self._client = docker.AutoVersionClient(**client_kwargs)
+            timeout = os.environ.get('DOCKER_CLIENT_TIMEOUT', DEFAULT_TIMEOUT_SECONDS)
+            self._client = docker.AutoVersionClient(timeout=timeout, **client_kwargs)
             self.api_version = self._client.version()['ApiVersion']
             # Set the version in the env so it can be used elsewhere
             os.environ['DOCKER_API_VERSION'] = self.api_version


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Fixes #147 by using env var DOCKER_CLIENT_TIMEOUT when instantiating the Docker client. If not set, defaults to docker.constants.DEFAULT_TIMEOUT_SECONDS