### PR TITLE
Change DOCKER_CLIENT_TIMEOUT to COMPOSE_HTTP_TIMEOUT

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -744,8 +744,8 @@ class Engine(BaseEngine):
         if not self._client:
             # To ensure version compatibility, we have to generate the kwargs ourselves
             client_kwargs = kwargs_from_env(assert_hostname=False)
-            timeout = os.environ.get('DOCKER_CLIENT_TIMEOUT', DEFAULT_TIMEOUT_SECONDS)
-            self._client = docker.AutoVersionClient(timeout=timeout, **client_kwargs)
+            timeout = os.environ.get('COMPOSE_HTTP_TIMEOUT', DEFAULT_TIMEOUT_SECONDS)
+            self._client = docker.AutoVersionClient(timeout=int(timeout), **client_kwargs)
             self.api_version = self._client.version()['ApiVersion']
             # Set the version in the env so it can be used elsewhere
             os.environ['DOCKER_API_VERSION'] = self.api_version
@@ -761,7 +761,7 @@ class Engine(BaseEngine):
         """
         Build common Docker Compose elements required to execute orchestrate,
         terminate, restart, etc.
-        
+
         :param temp_dir: A temporary directory usable as workspace
         :param behavior: x in x_operation_extra_args
         :param operation: Operation to perform, like, build, run, listhosts, etc


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Fixes #315

When using ansible-container with `DOCKER_CLIENT_TIMEOUT` env var, the warning message
`The DOCKER_CLIENT_TIMEOUT environment variable is deprecated.  Please use COMPOSE_HTTP_TIMEOUT instead.` appears on the console.

This message misleads users.
It is simple to use `COMPOSE_HTTP_TIMEOUT` instead of `DOCKER_CLIENT_TIMEOUT`.