### PR TITLE
Fix parsing of the --no-purge-last argument

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -90,7 +90,8 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--no-purge-last', action='store_false',
                            help=u'By default, Ansible Container will remove the '
                                 u'previously built image for your hosts. Disable '
-                                u'that with this flag.')
+                                u'that with this flag.',
+                           dest='purge_last', default=True)
     subparser.add_argument('--from-scratch', action='store_true',
                            help=u'Instead of running the Ansible playbook against '
                                 u'the existing copies of your containers, run the '


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### SUMMARY
Because of a discrepancy between the name of the flag (`--no-purge-last`) and that of the attribute (`purge_last`) checked in `post_build()` this command line argument had no effect.

This change makes sure that the boolean flag is stored with the correct attribute name.

Sorry for the lack of a test, but my non-existing Python coding skills prevent me from writing one.