### PR TITLE
Fixup of `update-authors.py` script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,21 +5,22 @@ Chris Houseknecht <chouseknecht@ansible.com>
 Joshua "jag" Ginsberg <jag@ansible.com>
 Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
-Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
+Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
 Dylan Silva <thaumos@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
-Todd Barr <tbarr@ansible.com>
+Ryan S. Brown <sb@ryansb.com>
 Will Thames <wthames@redhat.com>
 Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
+Todd Barr <tbarr@ansible.com>
 Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
-Sean Summers <ssummer3@nd.edu>
 Evan Zeimet <evan.zeimet@cdw.com>
+Sean Summers <ssummer3@nd.edu>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 Chrrrles Paul <chrrrles@users.noreply.github.com>
 Andrea De Pirro <andrea.depirro@yameveo.com>

--- a/update-authors.py
+++ b/update-authors.py
@@ -8,8 +8,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 import subprocess
+from collections import defaultdict
 
-user_scores = {}
+user_scores = defaultdict(int)
 
 git_log = subprocess.check_output("git log --shortstat --no-merges --pretty='%aN <%aE>'",
                                   shell=True)
@@ -23,16 +24,13 @@ while log_entries:
     for clause in commit_parts:
         count, action = clause.split(' ', 1)
         if action.endswith('(+)'):
-            commit_data['insertions'] += int(count)
+            user_scores[author] += int(count)
         elif action.endswith('(-)'):
-            commit_data['deletions'] += int(count)
+            user_scores[author] += int(count)
         else:
-            commit_data['files'] += int(count)
-    user_score = user_scores.setdefault(author, 0)
-    user_scores[author] = user_score + commit_data['insertions'] + commit_data['deletions']
+            user_scores[author] += int(count)
 
-user_scores = user_scores.items()
-sorted_user_scores = sorted(user_scores, key=lambda tpl: tpl[1], reverse=True)
+sorted_user_scores = sorted(user_scores.items(), key=lambda tpl: tpl[1], reverse=True)
 
 print("Ansible Container has been contribued to by the following authors:\n"
       "This list is automatically generated - please file an issue for corrections)\n")


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### SUMMARY

The update script for the AUTHORS file was ignoring the number of files,
this commit changes it to count files in the author scoring and switches
to use `defaultdict` instead of setdefault.