### PR TITLE
Python 3-ify the `pre-commit` script so it works on py3-only hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,19 +14,19 @@ Charlie Drage <charlie@charliedrage.com>
 Ryan Brown <sb@ryansb.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
 Will Thames <wthames@redhat.com>
-Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
+Grzegorz Nosek <root@localdomain.pl>
 Todd Barr <tbarr@ansible.com>
-Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
+Daniel Heitmann <dictvm@horrendum.de>
 Evan Zeimet <evan.zeimet@cdw.com>
 Sean Summers <ssummer3@nd.edu>
 Balazs Zagyvai <github.zagyi@spamgourmet.com>
-Ali Asad Lotia <ali.asad.lotia@gmail.com>
+Shea Stewart <shea.stewart@arctiq.ca>
+Gerard Braad <me@gbraad.nl>
 Chrrrles Paul <chrrrles@users.noreply.github.com>
 Andrea De Pirro <andrea.depirro@yameveo.com>
 Jeff Geerling <geerlingguy@mac.com>
-Shea Stewart <shea.stewart@arctiq.ca>
-Gerard Braad <me@gbraad.nl>
-Trishna Guha <trishnaguha17@gmail.com>
 Sidharth Surana <ssurana@vmware.com>
+Trishna Guha <trishnaguha17@gmail.com>
+Ali Asad Lotia <ali.asad.lotia@gmail.com>

--- a/update-authors.py
+++ b/update-authors.py
@@ -14,13 +14,12 @@ user_scores = defaultdict(int)
 
 git_log = subprocess.check_output("git log --shortstat --no-merges --pretty='%aN <%aE>'",
                                   shell=True)
-log_entries = git_log.strip().split('\n')
+log_entries = git_log.decode('utf-8').strip().split('\n')
 while log_entries:
     author = log_entries.pop(0)
     _ = log_entries.pop(0)
     commit_line = log_entries.pop(0)
     commit_parts = [s.strip() for s in commit_line.split(', ')]
-    commit_data = {'files': 0, 'insertions': 0, 'deletions': 0}
     for clause in commit_parts:
         count, action = clause.split(' ', 1)
         if action.endswith('(+)'):


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### SUMMARY

Commits on Py3-only hosts would fail if the `pre-commit` scripts were enabled with:

```
Traceback (most recent call last):
  File "update-authors.py", line 17, in <module>
    log_entries = git_log.strip().split('\n')
TypeError: a bytes-like object is required, not 'str'
```
