### PR TITLE
Brucellino patch typo containery

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -229,7 +229,7 @@ def commandline():
         logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.')
         sys.exit(1)
     except exceptions.AnsibleContainerConfigException as e:
-        logger.error('Invalid containery.yml: {}'.format(e.message))
+        logger.error('Invalid container.yml: {}'.format(e.message))
     except Exception as e:
         if args.debug:
             logger.exception(e)

--- a/docs/rst/container_yml/template.rst
+++ b/docs/rst/container_yml/template.rst
@@ -380,5 +380,5 @@ and `Jinja2 Filters <http://docs.ansible.com/ansible/playbooks_filters.html>`_.
 
     Ansible Jinja filters and lookups are only available if Ansible is installed on the host where Ansible Container runs.
     Template rendering occurs outside of the Ansible Build Container, so access to Ansible filters and lookups requires that
-    Ansible be installed locally. If Ansible is not installed, and ``containery.yml`` includes references to Ansible filters
+    Ansible be installed locally. If Ansible is not installed, and ``container.yml`` includes references to Ansible filters
     and lookups, an error will occur.


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There was a simple typo in the error log message, which was bugging me. I tried to find out whether there was some rationale for the use of `containery` instead of `container`, but the internet fell silent. 

This doesn't fix anything that was previously broken, but makes the error message English.
