### PR TITLE
Attempting to close #337

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Todd Barr <tbarr@ansible.com>
 Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
 Ted Timmons <ted@perljam.net>
+Bruce Becker <brucellino@gmail.com>
 Evan Zeimet <evan.zeimet@cdw.com>
 Sean Summers <ssummer3@nd.edu>
 Balazs Zagyvai <github.zagyi@spamgourmet.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docker-compose==1.9.0
 docker-py==1.10.6
-Jinja2==2.8
-PyYAML==3.11
-requests==2.7.0
+Jinja2>=2.8
+PyYAML>=3.11
+requests==2.11.1
 six


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- Bumping requests version to match [docker/docker-py](https://github.com/docker/docker-py/blob/1.10.6/requirements.txt#L1)
- Attempting to set a minimum for Jinja2 and PyYAML, rather than a hard version.

Fixes #337 
