### PR TITLE
Surface --list-host errors

### DIFF
--- a/container/exceptions.py
+++ b/container/exceptions.py
@@ -59,4 +59,7 @@ class AnsibleContainerConfigException(Exception):
 class AnsibleContainerMissingPersistentVolumeClaim(Exception):
     pass
 
+class AnsibleContainerListHostsException(Exception):
+    pass
+
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
If `ansible-playbook --list-hosts main.yml` fails, Ansible Container keeps running. It errors later with an unrelated and confusing message, leaving the user confused. The only way to then find the actual error is to run the command again with the `--debug` option, wait for the error, and then scroll back through screens of output.

This change inspects the stdout lines from the above command looking for 'exited with code 0'. If that does not exist, then something is wrong, most likely with they playbook's syntax. The stdout from the command is logged to the console, and execution halts, leaving the user alerted to exactly what went wrong.