### PR TITLE
Custom tagging for push and shipit

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -165,7 +165,7 @@ def subcmd_push_parser(parser, subparser):
                            help=(u'A custom tag to apply to the image before pushing. '
                                  u'For example, to tag and push images with "latest": '
                                  u'--tag latest'),
-                           dest='push_tag', default=None)
+                           dest='tag', default=None)
     subcmd_common_parsers(parser, subparser, 'push')
 
 def subcmd_version_parser(parser, subparser):

--- a/container/cli.py
+++ b/container/cli.py
@@ -162,9 +162,9 @@ def subcmd_push_parser(parser, subparser):
                                  u'"https://registry.example.com:5000/myproject"'),
                            dest='push_to', default=None)
     subparser.add_argument('--tag', action='store',
-                           help = (u'A custom tag to apply to the image before pushing. '
-                                   u'For example, to tag and push images with "latest": ',
-                                   u'--tag latest'),
+                           help=(u'A custom tag to apply to the image before pushing. '
+                                 u'For example, to tag and push images with "latest": '
+                                 u'--tag latest'),
                            dest='push_tag', default=None)
     subcmd_common_parsers(parser, subparser, 'push')
 

--- a/container/cli.py
+++ b/container/cli.py
@@ -161,6 +161,7 @@ def subcmd_push_parser(parser, subparser):
                                  u'including the namespace. If passing a URL, an example would be: '
                                  u'"https://registry.example.com:5000/myproject"'),
                            dest='push_to', default=None)
+    subparser.add_argument('--tag', action='store', dest='push_tag', default=None)
     subcmd_common_parsers(parser, subparser, 'push')
 
 def subcmd_version_parser(parser, subparser):

--- a/container/cli.py
+++ b/container/cli.py
@@ -161,7 +161,11 @@ def subcmd_push_parser(parser, subparser):
                                  u'including the namespace. If passing a URL, an example would be: '
                                  u'"https://registry.example.com:5000/myproject"'),
                            dest='push_to', default=None)
-    subparser.add_argument('--tag', action='store', dest='push_tag', default=None)
+    subparser.add_argument('--tag', action='store',
+                           help = (u'A custom tag to apply to the image before pushing. '
+                                   u'For example, to tag and push images with "latest": ',
+                                   u'--tag latest'),
+                           dest='push_tag', default=None)
     subcmd_common_parsers(parser, subparser, 'push')
 
 def subcmd_version_parser(parser, subparser):

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -247,7 +247,7 @@ class Engine(BaseEngine):
         exit_status = build_container_info['Status']
         return '(0)' in exit_status
 
-    def get_config_for_shipit(self, pull_from=None, url=None, namespace=None):
+    def get_config_for_shipit(self, pull_from=None, url=None, namespace=None, tag=None):
         '''
         Retrieve the configuration needed to run the shipit command
 
@@ -275,7 +275,7 @@ class Engine(BaseEngine):
         for host, service_config in config.get('services', {}).items():
             if host in orchestrated_hosts:
                 image_id, image_buildstamp = get_latest_image_for(self.project_name, host, client)
-                image = '{0}-{1}:{2}'.format(self.project_name, host, image_buildstamp)
+                image = '{0}-{1}:{2}'.format(self.project_name, host, tag or image_buildstamp)
                 if image_path:
                     image = '{0}/{1}'.format(image_path, image)
                 service_config.update({u'image':  image})

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -768,7 +768,7 @@ class Engine(BaseEngine):
             raise AnsibleContainerDockerConfigFileException("Failed to write docker registry config to %s - %s" %
                                                             (path, str(exc)))
 
-    def push_latest_image(self, host, url=None, namespace=None):
+    def push_latest_image(self, host, url=None, namespace=None, tag=None):
         '''
         :param host: The host in the container.yml to push
         :parm url: URL of the registry to which images will be pushed
@@ -778,6 +778,7 @@ class Engine(BaseEngine):
         client = self.get_client()
         image_id, image_buildstamp = get_latest_image_for(self.project_name,
                                                           host, client)
+        tag = tag or image_buildstamp
 
         repository = "%s/%s-%s" % (namespace, self.project_name, host)
         if url != self.default_registry_url:
@@ -785,11 +786,11 @@ class Engine(BaseEngine):
             repository = "%s/%s" % (re.sub('/$', '', url), repository)
 
         logger.info('Tagging %s' % repository)
-        client.tag(image_id, repository, tag=image_buildstamp)
+        client.tag(image_id, repository, tag=tag)
 
-        logger.info('Pushing %s:%s...' % (repository, image_buildstamp))
+        logger.info('Pushing %s:%s...' % (repository, tag))
         stream = client.push(repository,
-                             tag=image_buildstamp,
+                             tag=tag,
                              stream=True)
         last_status = None
         for data in stream:

--- a/container/engine.py
+++ b/container/engine.py
@@ -254,7 +254,7 @@ class BaseEngine(object):
     def get_config(self):
         raise NotImplementedError()
 
-    def get_config_for_shipit(self, url=None, namespace=None):
+    def get_config_for_shipit(self, url=None, namespace=None, tag=None):
         '''
         Get the configuration needed by cmdrun_shipit. Result should include
         the *options* attribute for each service, as it may contain cluster
@@ -423,7 +423,7 @@ def cmdrun_restart(base_path, engine_name, service=[], **kwargs):
         engine_obj.restart('restart', temp_dir, hosts=hosts)
 
 
-def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, push_tag=None, **kwargs):
+def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, tag=None, **kwargs):
     assert_initialized(base_path)
     engine_args = kwargs.copy()
     engine_args.update(locals())
@@ -452,11 +452,11 @@ def cmdrun_push(base_path, engine_name, username=None, password=None, email=None
     logger.info('Pushing to "%s/%s' % (re.sub(r'/$', '', url), namespace))
 
     for host in engine_obj.hosts_touched_by_playbook():
-        engine_obj.push_latest_image(host, url=url, namespace=namespace, tag=push_tag)
+        engine_obj.push_latest_image(host, url=url, namespace=namespace, tag=tag)
     logger.info('Done!')
 
 
-def cmdrun_shipit(base_path, engine_name, pull_from=None, **kwargs):
+def cmdrun_shipit(base_path, engine_name, pull_from=None, tag=None, **kwargs):
     assert_initialized(base_path)
     engine_args = kwargs.copy()
     engine_args.update(locals())
@@ -491,7 +491,7 @@ def cmdrun_shipit(base_path, engine_name, pull_from=None, **kwargs):
                           "registry or provide a namespace for the registry in container.yml" % (url, str(exc))
                 raise AnsibleContainerRegistryAttributeException(msg)
 
-    config = engine_obj.get_config_for_shipit(pull_from=pull_from, url=url, namespace=namespace)
+    config = engine_obj.get_config_for_shipit(pull_from=pull_from, url=url, namespace=namespace, tag=tag)
 
     shipit_engine_obj = load_shipit_engine(AVAILABLE_SHIPIT_ENGINES[shipit_engine_name]['cls'],
                                            config=config,

--- a/container/engine.py
+++ b/container/engine.py
@@ -240,7 +240,7 @@ class BaseEngine(object):
         """
         raise NotImplementedError()
 
-    def push_latest_image(self, host, url=None, namespace=None):
+    def push_latest_image(self, host, url=None, namespace=None, tag=None):
         """
         Push the latest built image for a host to a registry
 
@@ -423,7 +423,7 @@ def cmdrun_restart(base_path, engine_name, service=[], **kwargs):
         engine_obj.restart('restart', temp_dir, hosts=hosts)
 
 
-def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, **kwargs):
+def cmdrun_push(base_path, engine_name, username=None, password=None, email=None, push_to=None, push_tag=None, **kwargs):
     assert_initialized(base_path)
     engine_args = kwargs.copy()
     engine_args.update(locals())
@@ -452,7 +452,7 @@ def cmdrun_push(base_path, engine_name, username=None, password=None, email=None
     logger.info('Pushing to "%s/%s' % (re.sub(r'/$', '', url), namespace))
 
     for host in engine_obj.hosts_touched_by_playbook():
-        engine_obj.push_latest_image(host, url=url, namespace=namespace)
+        engine_obj.push_latest_image(host, url=url, namespace=namespace, tag=push_tag)
     logger.info('Done!')
 
 

--- a/container/shipit/base_engine.py
+++ b/container/shipit/base_engine.py
@@ -70,6 +70,10 @@ class BaseShipItEngine(object):
                                   u'ansible/shipit_config/kubernetes.' % self.name),
                             dest='save_config', default=False)
 
+        parser.add_argument('--tag', action='store',
+                            help=(u'Name of a tag to pull down'),
+                            dest='tag', default=None)
+
         egroup = parser.add_mutually_exclusive_group()
         egroup.add_argument('--pull-from', action='store',
                             help=u'Name of a registry defined in container.yml or the actual URL the cluster will '


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Kind of touches on #125 

This PR adds the `--tag` option to the `push` subcommand, allowing you to specify a custom tag for your image. This custom tag will be applied to your image, and then that tag will be pushed to your repository (instead of the default, `image_buildstamp`).

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
$ ansible-container push --push-to ansibleapp
Pushing to "docker.io/ansibleapp
Attaching to ansible_ansible-container_1
Cleaning up Ansible Container builder...
Tagging docker.io/ansibleapp/elk-ansibleapp-elasticsearch
Pushing docker.io/ansibleapp/elk-ansibleapp-elasticsearch:20170201164646...
The push refers to a repository [docker.io/ansibleapp/elk-ansibleapp-elasticsearch]
Preparing
Layer already exists
20170201164646: digest: sha256:85bf0ba4adf4264ed263ec50e48542cffff6cae5a2ed01c9dac8fed813535bcd size: 1350
Done!
```

After:

```
 $ ansible-container push --push-to ansibleapp --tag latest
Pushing to "docker.io/ansibleapp
Attaching to ansible_ansible-container_1
Cleaning up Ansible Container builder...
Tagging docker.io/ansibleapp/elk-ansibleapp-elasticsearch
Pushing docker.io/ansibleapp/elk-ansibleapp-elasticsearch:latest...
The push refers to a repository [docker.io/ansibleapp/elk-ansibleapp-elasticsearch]
Preparing
Layer already exists
latest: digest: sha256:85bf0ba4adf4264ed263ec50e48542cffff6cae5a2ed01c9dac8fed813535bcd size: 1350
Done!
```

Stdout for ansible-container shipit is unchanged, but the generated role/tasks/main.yml looks like this:

Before (ansible-container shipit openshift --pull-from ansibleapp):

```

- oso_deployment:
    project_name: elk-ansibleapp
    labels:
      app: elk-ansibleapp
      service: elasticsearch
    deployment_name: elasticsearch
    containers:
    - securityContext: {}
      name: elasticsearch
      image: docker.io/ansibleapp/elk-ansibleapp-elasticsearch:None
      env:
        ES_JAVA_OPTS: -Xms2g -Xmx2g
      workingDir: /usr/share/elasticsearch/bin
      args:
      - ./elasticsearch
      ports:
      - 9200
      - 9300
    replace: true
    replicas: '{{ replicas if replicas is defined else 3 }}'
  register: output
```

After (ansible-container shipit openshift --pull-from ansibleapp --tag latest):

```

- oso_deployment:
    project_name: elk-ansibleapp
    labels:
      app: elk-ansibleapp
      service: elasticsearch
    deployment_name: elasticsearch
    containers:
    - securityContext: {}
      name: elasticsearch
      image: docker.io/ansibleapp/elk-ansibleapp-elasticsearch:latest
      env:
        ES_JAVA_OPTS: -Xms2g -Xmx2g
      workingDir: /usr/share/elasticsearch/bin
      args:
      - ./elasticsearch
      ports:
      - 9200
      - 9300
    replace: true
    replicas: '{{ replicas if replicas is defined else 3 }}'
  register: output
```