### PR TITLE
Add reference docs for --tag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,8 +11,10 @@ Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
 Ryan Brown <sb@ryansb.com>
 Dylan Silva <thaumos@users.noreply.github.com>
+Fabian von Feilitzsch <fabianvf@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
+Gerard Braad <me@gbraad.nl>
 Will Thames <wthames@redhat.com>
 Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
@@ -23,6 +25,7 @@ Ted Timmons <ted@perljam.net>
 Bruce Becker <brucellino@gmail.com>
 Evan Zeimet <evan.zeimet@cdw.com>
 Sean Summers <ssummer3@nd.edu>
+John Matthews <jwmatthews@gmail.com>
 Balazs Zagyvai <github.zagyi@spamgourmet.com>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 Chrrrles Paul <chrrrles@users.noreply.github.com>
@@ -30,6 +33,5 @@ Andrea De Pirro <andrea.depirro@yameveo.com>
 John R Barker <john@johnrbarker.com>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
-Gerard Braad <me@gbraad.nl>
 Trishna Guha <trishnaguha17@gmail.com>
 Sidharth Surana <ssurana@vmware.com>

--- a/docs/rst/reference/push.rst
+++ b/docs/rst/reference/push.rst
@@ -14,10 +14,6 @@ password, it is used as part of your credentials; otherwise, the user is prompte
 Ansible Container performs a login for you. The credentials are stored in
 your container engine's configuration for future use.
 
-.. option:: --username <username>
-
-The username to use when logging into the registry.
-
 .. option:: --email <email>
 
 The email address associated with your username in the registry.
@@ -30,6 +26,24 @@ The password used to authenticate your user with the registry.
 
 Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
 push images. If passing a URL, an example would be 'https://registry.example.com:5000/myproject'.
+
+.. option:: --roles-path <path>
+
+**New in version 0.2.0**
+
+If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
+
+If ``--roles-path`` was used during the `build` process, then pass the same option to the `push` command so that ``main.yml`` can be parsed.
+
+.. option:: --tag <tag>
+
+**New in version 0.3.0**
+
+Tag the image with the provided tag value before performing the push.
+
+.. option:: --username <username>
+
+The username to use when logging into the registry.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
@@ -46,12 +60,3 @@ Mount one or more volumes to the Ansible Builder Container. Specify volumes as s
 volume format.
 
 If ``--with-volumes`` was used during the `build` process to access roles or includes, then pass the same option to the `push` command so that ``main.yml`` can be parsed. 
-
-.. option:: --roles-path LOCAL_PATH
-
-**New in version 0.2.0**
-
-If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-
-If ``--roles-path`` was used during the `build` process, then pass the same option to the `push` command so that ``main.yml`` can be parsed. 
-

--- a/docs/rst/reference/shipit/kube.rst
+++ b/docs/rst/reference/shipit/kube.rst
@@ -20,21 +20,41 @@ for details on how directives are mapped and for available Cloud options.
     Before ``shipit`` starts, the build container is started, and Ansible Playbook is
     invoked with the ``--list-hosts`` option to inspect ``main.yml`` and return the list of hosts
     it touches. Supply the same ``--roles-path``, ``--with-volumes`` and ``--with-variables`` options
-    passed to the``build`` command to ensure that ``main.yml`` can be parsed and interpreted.
+    passed to the ``build`` command to ensure that ``main.yml`` can be parsed and interpreted.
 
 .. option:: --help
 
 Display usage help.
+
+.. option:: --local-images
+
+**New in version 0.3.0**
+
+Use images directly from the local image cache managed by the Docker daemon. Prevents the automatic use of the default registry URL.
+
+.. option:: --pull-from <registry name>
+
+Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
+pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
+
+.. option:: --roles-path LOCAL_PATH
+
+**New in version 0.2.0**
+
+If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
+
+If ``--roles-path`` was used during the `build` process, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed.
 
 .. option:: --save-config
 
 In addition to creating the playbook and role, creates a *shipit_config/kubernetes* directory and writes out each
 JSON config file used to create the Kubernetes services and deployments for your application.
 
-.. option:: --pull-from <registry name>
+.. option:: --tag <tag>
 
-Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
-pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
+**New in version 0.3.0**
+
+Use a custom tag value when pulling images.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
@@ -51,20 +71,3 @@ Mount one or more volumes to the Ansible Builder Container. Specify volumes as s
 volume format.
 
 If ``--with-volumes`` was used during the `build` process to access roles or includes, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed. 
-
-.. option:: --roles-path LOCAL_PATH
-
-**New in version 0.2.0**
-
-If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-
-If ``--roles-path`` was used during the `build` process, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed. 
-
-.. option:: --local-images
-
-**New in version 0.3.0**
-
-Use images directly from the local image cache managed by the Docker daemon. Prevents the automatic use of the default registry URL.
-
-
-

--- a/docs/rst/reference/shipit/openshift.rst
+++ b/docs/rst/reference/shipit/openshift.rst
@@ -18,21 +18,41 @@ for details on how directives are mapped and for available Cloud options.
     Before ``shipit`` starts, the build container is started, and Ansible Playbook is
     invoked with the ``--list-hosts`` option to inspect ``main.yml`` and return the list of hosts
     it touches. Supply the same ``--roles-path``, ``--with-volumes`` and ``--with-variables``
-    options passed to the``build`` command to ensure that ``main.yml`` can be parsed and interpreted.
+    options passed to the ``build`` command to ensure that ``main.yml`` can be parsed and interpreted.
 
 .. option:: --help
 
 Display usage help.
+
+.. option:: --local-images
+
+**New in version 0.3.0**
+
+Use images directly from the local image cache managed by the Docker daemon. Prevents the automatic use of the default registry URL.
+
+.. option:: --pull-from <registry name>
+
+Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
+pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
+
+.. option:: --roles-path LOCAL_PATH
+
+**New in version 0.2.0**
+
+If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
+
+If ``--roles-path`` was used during the `build` process, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed.
 
 .. option:: --save-config
 
 In addition to creating the playbook and role, creates a *shipit_config/openshift* directory and writes out each
 JSON config file used to create the openshift services and deployments for your application.
 
-.. option:: --pull-from <registry name>
+.. option:: --tag <tag>
 
-Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
-pull images. If passing a URL, an example would be 'registry.example.com:5000/myproject'.
+**New in version 0.3.0**
+
+Use a custom tag value when pulling images.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
@@ -49,18 +69,3 @@ Mount one or more volumes to the Ansible Builder Container. Specify volumes as s
 volume format.
 
 If ``--with-volumes`` was used during the `build` process to access roles or includes, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed. 
-
-.. option:: --roles-path LOCAL_PATH
-
-**New in version 0.2.0**
-
-If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-
-If ``--roles-path`` was used during the `build` process, then pass the same option to the `shipit` command so that ``main.yml`` can be parsed. 
-
-.. option:: --local-images
-
-**New in version 0.3.0**
-
-Use images directly from the local image cache managed by the Docker daemon. Prevents the automatic use of the default registry URL.
-


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### SUMMARY
Follow-up to #372. Adds reference docs for `--tag` option on both `push` and `shipit` commands. 