### PR TITLE
Added option "--use-vault-password-file"

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -107,6 +107,8 @@ def subcmd_build_parser(parser, subparser):
     subparser.add_argument('--services', action='store',
                            help=u'Rather than perform an orchestrated build, only build specific services.',
                            nargs='+', dest='service', default=None)
+    subparser.add_argument('--use-vault-password-file', action='store_true',
+                           help=u'Use ansible_vault_password.txt from ansible folder', dest='use_vault_password_file',default=False)
     subparser.add_argument('ansible_options', action='store',
                            help=u'Provide additional commandline arguments to '
                                 u'Ansible in executing your playbook. If you '

--- a/container/templates/build-docker-compose.j2.yml
+++ b/container/templates/build-docker-compose.j2.yml
@@ -2,7 +2,7 @@ ansible-container:
   # If no $DOCKER_HOST then we need to run privileged so we can access /var/run/docker.sock
   {% if not env.DOCKER_HOST %}privileged: true{% endif %}
   image: "{{ builder_img_id }}"
-  command: "/usr/local/bin/builder.sh /usr/bin/ansible-playbook {% if params.debug %}-vvv{% endif %} -i /etc/ansible/ansible-container-inventory.py -c docker {{ params.ansible_options | join(' ')  }} main.yml"
+  command: "/usr/local/bin/builder.sh /usr/bin/ansible-playbook {% if params.debug %}-vvv{% endif %} -i /etc/ansible/ansible-container-inventory.py -c docker {% if params.use_vault_password_file %} --vault-password-file /ansible-container/ansible/ansible_vault_password.txt{% endif %} {{ params.ansible_options | join(' ')  }} main.yml"
   environment:
     {% if env.DOCKER_HOST %}- DOCKER_HOST{% else %}- DOCKER_HOST=unix:///var/run/docker.sock{% endif %}
     {% if env.DOCKER_TLS_VERIFY %}- DOCKER_TLS_VERIFY{% endif %}


### PR DESCRIPTION

##### ISSUE TYPE
 - Feature Pull Request
##### SUMMARY
Added option "--vault-password-file" that adds : "--vault-password-file ansible_vault_password.txt" to the ansible-playbook call in container/templates/build-docker-compose.j2.yml
The file ansible_vault_password.txt has to exist in ./ansible folder which is mounted as a volume in ansible builder container.

Fixes #381
