### PR TITLE
Fixed no message displayed on an Exception.

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -243,5 +243,5 @@ def commandline():
         if args.debug:
             logger.exception(e)
         else:
-            logger.error(e)
+            logger.error('Execution failed with {}'.format(type(e)))
         sys.exit(1)

--- a/container/cli.py
+++ b/container/cli.py
@@ -243,5 +243,6 @@ def commandline():
         if args.debug:
             logger.exception(e)
         else:
-            logger.error('Execution failed with {}'.format(type(e)))
+            msg = str(e) if str(e) else type(e)
+            logger.error('Execution failed with {}'.format(msg))
         sys.exit(1)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
When running  `ansible-container build` on a low-memory machine, it fails with a `MemoryError` with nothing displayed to the user. That's because `str(e)` returns an empty string.
Changed to provide a meaningful output.

Before:
```
Starting Docker Compose engine to build your images...
Attaching to ansible_ansible-container_1
#
```
After:
```
Starting Docker Compose engine to build your images...
Attaching to ansible_ansible-container_1
Execution failed with <type 'exceptions.MemoryError'>
#
```