### PR TITLE
Log refactor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,8 +5,8 @@ Joshua "jag" Ginsberg <jag@ansible.com>
 Chris Houseknecht <chouseknecht@ansible.com>
 Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
-Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Ryan Brown <sb@ryansb.com>
+Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,8 +4,8 @@ This list is automatically generated - please file an issue for corrections)
 Joshua "jag" Ginsberg <jag@ansible.com>
 Chris Houseknecht <chouseknecht@ansible.com>
 Shubham Minglani <shubham@linux.com>
-Matt Clay <matt@mystile.com>
 Ryan Brown <sb@ryansb.com>
+Matt Clay <matt@mystile.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,8 +3,8 @@ This list is automatically generated - please file an issue for corrections)
 
 Joshua "jag" Ginsberg <jag@ansible.com>
 Chris Houseknecht <chouseknecht@ansible.com>
-Shubham Minglani <shubham@linux.com>
 Ryan Brown <sb@ryansb.com>
+Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>

--- a/container/__init__.py
+++ b/container/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 __version__ = '0.9.0-pre'

--- a/container/__init__.py
+++ b/container/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .visibility import getLogger
-logger = getLogger(__name__)
-
 __version__ = '0.9.0-pre'

--- a/container/cli.py
+++ b/container/cli.py
@@ -266,7 +266,7 @@ def commandline():
         logger.error('Invalid container.yml: {}'.format(e.message))
     except Exception as e:
         if args.debug:
-            logger.exception('Unknown exception %s' % str(e), exc_info=e)
+            logger.exception('Unknown exception %s' % str(e))
         else:
             logger.error('Unknown exception', exc_info=e)
         sys.exit(1)

--- a/container/cli.py
+++ b/container/cli.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 import os
 import sys
@@ -231,7 +230,7 @@ def commandline():
     subparsers = parser.add_subparsers(title='subcommand', dest='subcommand')
     subparsers.required = True
     for subcommand in AVAILABLE_COMMANDS:
-        logger.debug('Registering subcommand %s', subcommand)
+        logger.debug('Registering subcommand', subcommand=subcommand)
         subparser = subparsers.add_parser(subcommand, help=AVAILABLE_COMMANDS[subcommand])
         globals()['subcmd_%s_parser' % subcommand](parser, subparser)
 
@@ -248,26 +247,26 @@ def commandline():
     try:
         getattr(core, u'cmdrun_{}'.format(args.subcommand))(**vars(args))
     except exceptions.AnsibleContainerAlreadyInitializedException as e:
-        logger.error('Ansible Container is already initialized')
+        logger.error('Ansible Container is already initialized', exc_info=e)
         sys.exit(1)
     except exceptions.AnsibleContainerNotInitializedException as e:
         logger.error('No Ansible Container project data found - do you need to '
-                     'run "ansible-container init"?')
+                     'run "ansible-container init"?', exc_info=e)
         sys.exit(1)
     except exceptions.AnsibleContainerNoAuthenticationProvidedException as e:
-        logger.exception(e)
+        logger.error('No authentication provided, unable to continue', exc_info=e)
         sys.exit(1)
     except exceptions.AnsibleContainerNoMatchingHosts:
-        logger.error('No matching service found in ansible/container.yml')
+        logger.error('No matching service found in ansible/container.yml', exc_info=e)
         sys.exit(1)
     except exceptions.AnsibleContainerHostNotTouchedByPlaybook:
-        logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.')
+        logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.', exc_info=e)
         sys.exit(1)
     except exceptions.AnsibleContainerConfigException as e:
         logger.error('Invalid container.yml: {}'.format(e.message))
     except Exception as e:
         if args.debug:
-            logger.exception(e)
+            logger.exception('Unknown exception %s' % str(e), exc_info=e)
         else:
-            logger.error(e)
+            logger.error('Unknown exception', exc_info=e)
         sys.exit(1)

--- a/container/cli.py
+++ b/container/cli.py
@@ -249,32 +249,32 @@ def commandline():
 
     try:
         getattr(core, u'cmdrun_{}'.format(args.subcommand))(**vars(args))
-    except exceptions.AnsibleContainerAlreadyInitializedException as e:
+    except exceptions.AnsibleContainerAlreadyInitializedException:
         logger.error('Ansible Container is already initialized', exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerNotInitializedException as e:
+    except exceptions.AnsibleContainerNotInitializedException:
         logger.error('No Ansible Container project data found - do you need to '
                 'run "ansible-container init"?', exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerNoAuthenticationProvidedException as e:
+    except exceptions.AnsibleContainerNoAuthenticationProvidedException:
         logger.error('No authentication provided, unable to continue', exc_info=True)
         sys.exit(1)
     except conductor_exc.AnsibleContainerConductorException as e:
         logger.error('Failure in conductor container: %s' % e.message, exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerNoMatchingHosts as e:
+    except exceptions.AnsibleContainerNoMatchingHosts:
         logger.error('No matching service found in ansible/container.yml', exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerHostNotTouchedByPlaybook as e:
+    except exceptions.AnsibleContainerHostNotTouchedByPlaybook:
         logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.', exc_info=True)
         sys.exit(1)
     except exceptions.AnsibleContainerConfigException as e:
         logger.error('Invalid container.yml: {}'.format(e.message))
-    except requests.exceptions.ConnectionError as e:
+    except requests.exceptions.ConnectionError:
         logger.error('Could not connect to container host. Check your docker config', exc_info=True)
     except Exception as e:
         if args.debug:
-            logger.exception('Unknown exception %s' % str(e), exc_info=True)
+            logger.exception('Unknown exception %s' % e, exc_info=True)
         else:
             logger.error('Unknown exception', exc_info=True)
         sys.exit(1)

--- a/container/cli.py
+++ b/container/cli.py
@@ -14,6 +14,7 @@ from . import core
 from . import config
 from . import exceptions
 from .utils import load_shipit_engine, AVAILABLE_SHIPIT_ENGINES
+from .conductor import exceptions as conductor_exc
 
 from logging import config
 LOGGING = {
@@ -257,6 +258,9 @@ def commandline():
         sys.exit(1)
     except exceptions.AnsibleContainerNoAuthenticationProvidedException as e:
         logger.error('No authentication provided, unable to continue', exc_info=True)
+        sys.exit(1)
+    except conductor_exc.AnsibleContainerConductorException as e:
+        logger.error('Failure in conductor container: %s' % e.message, exc_info=True)
         sys.exit(1)
     except exceptions.AnsibleContainerNoMatchingHosts as e:
         logger.error('No matching service found in ansible/container.yml', exc_info=True)

--- a/container/cli.py
+++ b/container/cli.py
@@ -8,6 +8,8 @@ import os
 import sys
 import argparse
 
+import requests.exceptions
+
 from . import core
 from . import config
 from . import exceptions
@@ -247,26 +249,28 @@ def commandline():
     try:
         getattr(core, u'cmdrun_{}'.format(args.subcommand))(**vars(args))
     except exceptions.AnsibleContainerAlreadyInitializedException as e:
-        logger.error('Ansible Container is already initialized', exc_info=e)
+        logger.error('Ansible Container is already initialized', exc_info=True)
         sys.exit(1)
     except exceptions.AnsibleContainerNotInitializedException as e:
         logger.error('No Ansible Container project data found - do you need to '
-                     'run "ansible-container init"?', exc_info=e)
+                'run "ansible-container init"?', exc_info=True)
         sys.exit(1)
     except exceptions.AnsibleContainerNoAuthenticationProvidedException as e:
-        logger.error('No authentication provided, unable to continue', exc_info=e)
+        logger.error('No authentication provided, unable to continue', exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerNoMatchingHosts:
-        logger.error('No matching service found in ansible/container.yml', exc_info=e)
+    except exceptions.AnsibleContainerNoMatchingHosts as e:
+        logger.error('No matching service found in ansible/container.yml', exc_info=True)
         sys.exit(1)
-    except exceptions.AnsibleContainerHostNotTouchedByPlaybook:
-        logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.', exc_info=e)
+    except exceptions.AnsibleContainerHostNotTouchedByPlaybook as e:
+        logger.error('The requested service(s) is not referenced in ansible/main.yml. Nothing to build.', exc_info=True)
         sys.exit(1)
     except exceptions.AnsibleContainerConfigException as e:
         logger.error('Invalid container.yml: {}'.format(e.message))
+    except requests.exceptions.ConnectionError as e:
+        logger.error('Could not connect to container host. Check your docker config', exc_info=True)
     except Exception as e:
         if args.debug:
-            logger.exception('Unknown exception %s' % str(e))
+            logger.exception('Unknown exception %s' % str(e), exc_info=True)
         else:
-            logger.error('Unknown exception', exc_info=e)
+            logger.error('Unknown exception', exc_info=True)
         sys.exit(1)

--- a/container/conductor-requirements.txt
+++ b/container/conductor-requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/docker/docker-py#egg=docker
+structlog[dev]

--- a/container/conductor-requirements.txt
+++ b/container/conductor-requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/docker/docker-py#egg=docker
 structlog[dev]
+docker-compose

--- a/container/conductor/__init__.py
+++ b/container/conductor/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 __version__ = '0.9pre'

--- a/container/conductor/cli.py
+++ b/container/conductor/cli.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 """
 cli.py - The console script for Ansible Container inside of the Conductor

--- a/container/conductor/cli.py
+++ b/container/conductor/cli.py
@@ -75,8 +75,8 @@ def commandline():
     containers_config = decoding_fn(args.config)
     conductor_config = AnsibleContainerConductorConfig(containers_config)
 
-    logger.debug('Starting Ansible Container Conductor: %s', args.command)
-    logger.debug('Services: %s', conductor_config.services)
+    logger.debug('Starting Ansible Container Conductor: %s' % args.command,
+        services=conductor_config.services)
     getattr(core, args.command)(args.engine, args.project_name,
                                 conductor_config.services,
                                 volume_data=conductor_config.volumes,

--- a/container/conductor/cli.py
+++ b/container/conductor/cli.py
@@ -75,7 +75,7 @@ def commandline():
     containers_config = decoding_fn(args.config)
     conductor_config = AnsibleContainerConductorConfig(containers_config)
 
-    logger.debug('Starting Ansible Container Conductor: %s' % args.command,
+    logger.debug('Starting Ansible Container Conductor: %s', args.command,
         services=conductor_config.services)
     getattr(core, args.command)(args.engine, args.project_name,
                                 conductor_config.services,

--- a/container/conductor/config.py
+++ b/container/conductor/config.py
@@ -57,16 +57,16 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def _process_top_level_sections(self):
         for section in ['volumes', 'registries']:
-            logger.debug('Processing %s section...', section)
+            logger.debug('Processing section...', section=section)
             setattr(self, section,
-                    self._process_section(self._config.get(section,
-                                                           ordereddict.ordereddict())))
+                    self._process_section(self._config.get(
+                        section, ordereddict.ordereddict())))
 
     def _process_services(self):
         services = ordereddict.ordereddict()
         for service, service_data in self._config.get(
                 'services', ordereddict.ordereddict()).items():
-            logger.debug('Processing service %s...', service)
+            logger.debug('Processing service...', service=service)
             processed = ordereddict.ordereddict()
             service_defaults = self.defaults.copy()
             for role_spec in service_data.get('roles', []):
@@ -84,7 +84,7 @@ class AnsibleContainerConductorConfig(Mapping):
                                         relax=True)
                 service_defaults.update(role_args, relax=True)
             processed.update(service_data, relax=True)
-            logger.debug('Renering service keys using %s', service_defaults)
+            logger.debug('Rendering service keys from defaults', defaults=service_defaults)
             services[service] = self._process_section(
                 processed,
                 templar=Templar(loader=None, variables=service_defaults)

--- a/container/conductor/config.py
+++ b/container/conductor/config.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 from collections import Mapping
 try:

--- a/container/conductor/core.py
+++ b/container/conductor/core.py
@@ -116,7 +116,7 @@ def apply_role_to_container(role, container_id, service_name, engine,
 def build(engine_name, project_name, services, cache=True,
           python_interpreter=None, ansible_options='', debug=False, **kwargs):
     engine = load_engine(['BUILD'], engine_name, project_name, services)
-    logger.info(u'%s integration engine loaded. Build starting.' %
+    logger.info(u'%s integration engine loaded. Build starting.',
         engine.display_name, project=project_name)
 
     for service_name, service in services.iteritems():
@@ -124,8 +124,8 @@ def build(engine_name, project_name, services, cache=True,
         cur_image_id = engine.get_image_id_by_tag(service['from'])
         # the fingerprint hash tracks cacheability
         fingerprint_hash = hashlib.sha256('%s::' % cur_image_id)
-        logger.debug(u'Base fingerprint hash = %s', service=service_name,
-                     hash=fingerprint_hash.hexdigest())
+        logger.debug(u'Base fingerprint hash = %s', fingerprint_hash.hexdigest(),
+                     service=service_name, hash=fingerprint_hash.hexdigest())
         cache_busted = not cache
 
         cur_container_id = engine.get_container_id_for_service(service_name)
@@ -148,8 +148,8 @@ def build(engine_name, project_name, services, cache=True,
                         logger.debug(u'Cached layer found for service',
                                      service=service_name, fingerprint=fingerprint_hash.hexdigest())
                         cur_image_id = cached_image_id
-                        logger.info(u'Applied role from cache', service=service_name,
-                                    role=role)
+                        logger.info(u'Applied role %s from cache', role,
+                                    service=service_name, role=role)
                         continue
                     else:
                         cache_busted = True
@@ -241,7 +241,7 @@ def stop(engine_name, project_name, services, **kwargs):
     for service_name in services:
         container_id = engine.get_container_id_for_service(service_name)
         if container_id:
-            logger.debug(u'Stopping %s...' % service_name)
+            logger.debug(u'Stopping %s...', service_name)
             engine.stop_container(container_id)
     logger.info(u'All services stopped.')
 
@@ -253,7 +253,7 @@ def deploy(engine_name, project_name, services, repository_data, playbook_dest, 
 
     # Verify all images are built
     for service_name in services:
-        logger.info(u'Verifying image for %s' % service_name)
+        logger.info(u'Verifying image for %s', service_name)
         image_id = engine.get_latest_image_id_for_service(service_name)
         if not image_id:
             logger.error(u'Missing image. Run "ansible-container build" '
@@ -272,8 +272,8 @@ def deploy(engine_name, project_name, services, repository_data, playbook_dest, 
     try:
         with open(os.path.join(playbook_dest, '%s.yml' % project_name), 'w') as ofs:
             yaml.safe_dump(playbook, ofs)
-    except OSError, e:
-        logger.error(u'Failure writing deployment playbook', exc_info=e)
+    except OSError:
+        logger.error(u'Failure writing deployment playbook', exc_info=True)
         raise
 
 

--- a/container/conductor/docker/__init__.py
+++ b/container/conductor/docker/__init__.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from ..visibility import getLogger
+logger = getLogger(__name__)
 
 """
 Implementation of the Docker-based engine integration

--- a/container/conductor/docker/deploy.py
+++ b/container/conductor/docker/deploy.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from ..visibility import getLogger
+logger = getLogger(__name__)
 
 """
 Translate the container.yml derived config into an Ansible playbook/role

--- a/container/conductor/docker/engine.py
+++ b/container/conductor/docker/engine.py
@@ -193,7 +193,7 @@ class Engine(BaseEngine):
         if params.get('devel'):
             from container import conductor
             conductor_path = os.path.dirname(conductor.__file__)
-            logger.debug(u"Binding conductor at %s into conductor container" % conductor_path)
+            logger.debug(u"Binding conductor at %s into conductor container", conductor_path)
             volumes[conductor_path] = {'bind': '/_ansible/conductor/conductor', 'mode': 'rw'}
 
         if command in ('login', 'push') and params.get('config_path'):
@@ -490,8 +490,9 @@ class Engine(BaseEngine):
 
             logger.debug('Context manifest:')
             for tarinfo_obj in tarball.getmembers():
-                logger.debug('tarball item: %s (%s bytes)' % (tarinfo_obj.name, tarinfo_obj.size),
-                    file=tarinfo_obj.name, bytes=tarinfo_obj.size, terse=True)
+                logger.debug('tarball item: %s (%s bytes)', tarinfo_obj.name,
+                             tarinfo_obj.size, file=tarinfo_obj.name,
+                             bytes=tarinfo_obj.size, terse=True)
             tarball.close()
             tarball_file.close()
             tarball_file = open(tarball_path, 'rb')
@@ -507,6 +508,10 @@ class Engine(BaseEngine):
                         line_json = json.loads(line)
                         if 'stream' in line_json:
                             line = line_json['stream']
+                        elif line_json.get('status') == 'Downloading':
+                            # skip over lines that give spammy byte-by-byte
+                            # progress of downloads
+                            continue
                     except ValueError:
                         pass
                     # this bypasses the fancy colorized logger for things that

--- a/container/conductor/docker/engine.py
+++ b/container/conductor/docker/engine.py
@@ -317,9 +317,10 @@ class Engine(BaseEngine):
                 '%s:latest' % self.image_name_for_service(service_name))
         except docker_errors.ImageNotFound:
             images = self.client.images.list(name=self.image_name_for_service(service_name))
-            logger.debug("Could not ':latest' image, searching for "
-                "other tags with same image name",
-                image_name=self.image_name_for_service(service_name))
+            logger.debug("Could not find the latest image for service, "
+                "searching for other tags with same image name",
+                image_name=self.image_name_for_service(service_name),
+                service=service_name)
 
             if not images:
                 return None

--- a/container/conductor/engine.py
+++ b/container/conductor/engine.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 CAPABILITIES = dict(
     BUILD='building container images',

--- a/container/conductor/loader.py
+++ b/container/conductor/loader.py
@@ -4,13 +4,12 @@ from __future__ import absolute_import
 import logging
 import importlib
 
-from .engine import CAPABILITIES
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 
 def load_engine(capabilities_needed, engine_name, project_name, services=[], **kwargs):
-    logger.debug(u"Loading capabilities %s for engine %s", ','.join(capabilities_needed), engine_name)
+    logger.debug(u"Loading engine capabilities", capabilities=capabilities_needed, engine=engine_name)
     conductor_module_name = __name__.rsplit('.', 1)[0]
     mod = importlib.import_module('.%s.engine' % engine_name,
                                   package=conductor_module_name)

--- a/container/conductor/utils.py
+++ b/container/conductor/utils.py
@@ -37,9 +37,9 @@ class MakeTempDir(object):
             logger.debug('Cleaning up temporary directory',
                 path=self.temp_dir)
             shutil.rmtree(self.temp_dir)
-        except Exception as e:
+        except Exception:
             logger.error('Failure cleaning up temp space', path=self.temp_dir,
-                exc_info=e)
+                    exc_info=True)
 
 conductor_dir = os.path.normpath(os.path.dirname(__file__))
 

--- a/container/conductor/utils.py
+++ b/container/conductor/utils.py
@@ -14,9 +14,13 @@ from distutils import dir_util
 
 from jinja2 import Environment, FileSystemLoader
 from ruamel import yaml, ordereddict
-from ansible.playbook.role.include import RoleInclude
-from ansible.vars import VariableManager
-from ansible.parsing.dataloader import DataLoader
+try:
+    from ansible.playbook.role.include import RoleInclude
+    from ansible.vars import VariableManager
+    from ansible.parsing.dataloader import DataLoader
+    HAS_ANSIBLE = True
+except ImportError:
+    HAS_ANSIBLE = False
 
 from .exceptions import AnsibleContainerConductorException
 
@@ -163,6 +167,8 @@ def create_role_from_templates(role_name=None, role_path=None,
 
 
 def resolve_role_to_path(role_name):
+    if not HAS_ANSIBLE:
+        raise ImportError('Unable to import Ansible python API')
     loader, variable_manager = DataLoader(), VariableManager()
     role_obj = RoleInclude.load(data=role_name, play=None,
                                 variable_manager=variable_manager,

--- a/container/conductor/visibility.py
+++ b/container/conductor/visibility.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# This is a copy of /container/visibility.py copied for accessibility inside
+# the conductor
+from __future__ import absolute_import
+
+import inspect
+import logging
+import sys
+
+from ruamel import ordereddict
+
+from structlog import wrap_logger
+from structlog.processors import JSONRenderer
+from structlog.dev import ConsoleRenderer
+from structlog.stdlib import filter_by_level
+from structlog.processors import format_exc_info, TimeStamper
+
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stderr,
+    format='%(message)s',
+)
+
+def local_var_info(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG or call_name != 'debug':
+        return event_dict
+    caller = inspect.stack()[3]
+    event_dict.update({
+        'locals': caller[0].f_locals,
+    })
+    return event_dict
+
+def _unroll_odict(od):
+    """Takes an ordereddict and rebuilds it as a regular dict
+
+    Only used in DEBUG mode, because logs below DEBUG are encoded
+    as JSON anyway."""
+    cleaned = {}
+    for key, value in od.items():
+        if isinstance(value, ordereddict.ordereddict):
+            cleaned[key] = _unroll_odict(value)
+        else:
+            cleaned[key] = value
+    return cleaned
+
+def unorder_dict(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        return event_dict
+    for key, value in event_dict.items():
+        if isinstance(value, ordereddict.ordereddict):
+            event_dict[key] = _unroll_odict(value)
+    return event_dict
+
+def add_caller_info(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        return event_dict
+    elif event_dict.get('terse'):
+        event_dict.pop('terse')
+        return event_dict
+    caller = inspect.stack()[3]
+
+    if 'caller_func' not in event_dict:
+        event_dict['caller_func'] = caller[0].f_code.co_name
+    if 'caller_file' not in event_dict:
+        event_dict['caller_file'] = caller[1]
+    if 'caller_line' not in event_dict:
+        event_dict['caller_line'] = caller[2]
+
+    return event_dict
+
+def alternate_dev_formatter():
+    debugging = ConsoleRenderer()
+    standard = JSONRenderer(sort_keys=True)
+    def with_memoized_loggers(logger, call_name, event_dict):
+        if logger.getEffectiveLevel() > logging.DEBUG:
+            return standard(logger, call_name, event_dict)
+        return debugging(logger, call_name, event_dict)
+    return with_memoized_loggers
+
+def getLogger(name):
+    return wrap_logger(
+        logging.getLogger(name),
+        processors=[
+            filter_by_level,
+            add_caller_info,
+            #local_var_info,
+            unorder_dict,
+            TimeStamper(fmt="ISO", utc=False),
+            format_exc_info,
+            alternate_dev_formatter()
+        ]
+    )

--- a/container/conductor/visibility.py
+++ b/container/conductor/visibility.py
@@ -6,13 +6,15 @@ from __future__ import absolute_import
 import inspect
 import logging
 import sys
+import json
 
 from ruamel import ordereddict
 
 from structlog import wrap_logger
 from structlog.processors import JSONRenderer
 from structlog.dev import ConsoleRenderer
-from structlog.stdlib import filter_by_level
+from structlog.stdlib import filter_by_level, add_logger_name
+from structlog.stdlib import BoundLogger, PositionalArgumentsFormatter
 from structlog.processors import format_exc_info, TimeStamper
 
 logging.basicConfig(
@@ -30,25 +32,12 @@ def local_var_info(logger, call_name, event_dict):
     })
     return event_dict
 
-def _unroll_odict(od):
-    """Takes an ordereddict and rebuilds it as a regular dict
-
-    Only used in DEBUG mode, because logs below DEBUG are encoded
-    as JSON anyway."""
-    cleaned = {}
-    for key, value in od.items():
-        if isinstance(value, ordereddict.ordereddict):
-            cleaned[key] = _unroll_odict(value)
-        else:
-            cleaned[key] = value
-    return cleaned
-
 def unorder_dict(logger, call_name, event_dict):
     if logger.getEffectiveLevel() > logging.DEBUG:
         return event_dict
     for key, value in event_dict.items():
         if isinstance(value, ordereddict.ordereddict):
-            event_dict[key] = _unroll_odict(value)
+            event_dict[key] = json.dumps(value)
     return event_dict
 
 def add_caller_info(logger, call_name, event_dict):
@@ -81,12 +70,15 @@ def getLogger(name):
     return wrap_logger(
         logging.getLogger(name),
         processors=[
+            PositionalArgumentsFormatter(),
             filter_by_level,
+            add_logger_name,
             add_caller_info,
             #local_var_info,
             unorder_dict,
             TimeStamper(fmt="ISO", utc=False),
             format_exc_info,
             alternate_dev_formatter()
-        ]
+        ],
+        wrapper_class=BoundLogger,
     )

--- a/container/config.py
+++ b/container/config.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 import os
 import json
@@ -63,8 +62,7 @@ class AnsibleContainerConfig(Mapping):
 
         self._resolve_defaults(config)
 
-        logger.debug(u"Config:\n%s" % json.dumps(config,
-                                                 indent=4))
+        logger.debug(u"Parsed config", config=config)
         self._config = config
 
     def _resolve_defaults(self, config):
@@ -79,8 +77,7 @@ class AnsibleContainerConfig(Mapping):
         if self.var_file:
             defaults.update(self._get_variables_from_file(), relax=True)
         defaults.update(self._get_environment_variables(), relax=True)
-        logger.debug(u'Template variables:\n %s' % json.dumps(defaults,
-                                                              indent=4))
+        logger.debug(u'Resolved template variables', template_vars=defaults)
 
     def _get_environment_variables(self):
         '''
@@ -95,6 +92,7 @@ class AnsibleContainerConfig(Mapping):
         for var, value in [(k, v) for k, v in six.iteritems(os.environ)
                            if k.startswith('AC_')]:
             env_vars[var[3:].lower()] = value
+        logger.debug(u'Read environment variables', env_vars=env_vars)
         return env_vars
 
     def _get_variables_from_file(self):
@@ -110,7 +108,7 @@ class AnsibleContainerConfig(Mapping):
             raise AnsibleContainerConfigException(
                 u'Variables file "%s" not found. (I looked in "%s" for it.)' % (
                     filename, dirname))
-        logger.debug("Use variable file: %s" % abspath)
+        logger.debug("Use variable file: %s" % abspath, file=abspath)
 
         if os.path.splitext(abspath)[-1].lower().endswith(('yml', 'yaml')):
             try:

--- a/container/config.py
+++ b/container/config.py
@@ -76,7 +76,11 @@ class AnsibleContainerConfig(Mapping):
         defaults = config.setdefault('defaults', ordereddict.ordereddict())
         if self.var_file:
             defaults.update(self._get_variables_from_file(), relax=True)
-        defaults.update(self._get_environment_variables(), relax=True)
+        logger.debug('The default type is', defaults=str(type(defaults)), config=str(type(config)))
+        if type(defaults) == ordereddict.ordereddict:
+            defaults.update(self._get_environment_variables(), relax=True)
+        else:
+            defaults.update(self._get_environment_variables())
         logger.debug(u'Resolved template variables', template_vars=defaults)
 
     def _get_environment_variables(self):

--- a/container/config.py
+++ b/container/config.py
@@ -112,7 +112,7 @@ class AnsibleContainerConfig(Mapping):
             raise AnsibleContainerConfigException(
                 u'Variables file "%s" not found. (I looked in "%s" for it.)' % (
                     filename, dirname))
-        logger.debug("Use variable file: %s" % abspath, file=abspath)
+        logger.debug("Use variable file: %s", abspath, file=abspath)
 
         if os.path.splitext(abspath)[-1].lower().endswith(('yml', 'yaml')):
             try:

--- a/container/core.py
+++ b/container/core.py
@@ -168,7 +168,6 @@ def cmdrun_run(base_path, project_name, engine_name, var_file=None, cache=True,
         logger.error(msg, engine=engine_obj.display_name)
         raise Exception(msg)
 
-    print(engine_obj.services)
     for service in engine_obj.services:
         if not engine_obj.service_is_running(service):
             logger.debug(u'Service not running, will be started by `run`'

--- a/container/exceptions.py
+++ b/container/exceptions.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 
 class AnsibleContainerException(Exception):

--- a/container/temp.py
+++ b/container/temp.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 
 import tempfile
@@ -15,12 +14,12 @@ class MakeTempDir(object):
 
     def __enter__(self):
         self.temp_dir = tempfile.mkdtemp()
-        logger.debug('Using temporary directory %r...', self.temp_dir)
+        logger.debug('Using temporary directory', path=self.temp_dir)
         return os.path.realpath(self.temp_dir)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            logger.debug('Cleaning up temporary directory %r...', self.temp_dir)
+            logger.debug('Cleaning up temporary directory', path=self.temp_dir)
             shutil.rmtree(self.temp_dir)
         except Exception:
-            logger.exception('Failure cleaning up temp space %r', self.temp_dir)
+            logger.exception('Failure cleaning up temp space', path=self.temp_dir)

--- a/container/utils.py
+++ b/container/utils.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import logging
-
-logger = logging.getLogger(__name__)
+from .visibility import getLogger
+logger = getLogger(__name__)
 
 import os
 import importlib
@@ -61,8 +60,7 @@ def jinja_render_to_temp(template_file, temp_dir, dest_file, **context):
     j2_env = Environment(loader=FileSystemLoader(j2_tmpl_path))
     j2_tmpl = j2_env.get_template(template_file)
     rendered = j2_tmpl.render(dict(temp_dir=temp_dir, **context))
-    logger.debug('Rendered Jinja Template:')
-    logger.debug(rendered.encode('utf8'))
+    logger.debug('Rendered Jinja Template:', body=rendered.encode('utf8'))
     open(os.path.join(temp_dir, dest_file), 'wb').write(
         rendered.encode('utf8'))
 
@@ -108,7 +106,7 @@ def load_engine(engine_name='', base_path='', **kwargs):
     """
     mod = importlib.import_module('container.%s.engine' % engine_name)
     project_name = os.path.basename(base_path).lower()
-    logger.debug('Project name is %s', project_name)
+    logger.debug('Engine loaded for project', name=project_name, path=base_path)
     return mod.Engine(base_path, project_name, kwargs)
 
 

--- a/container/visibility.py
+++ b/container/visibility.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import inspect
+import logging
+import sys
+
+from ruamel import ordereddict
+
+from structlog import wrap_logger
+from structlog.processors import JSONRenderer
+from structlog.dev import ConsoleRenderer
+from structlog.stdlib import filter_by_level
+from structlog.processors import format_exc_info, TimeStamper
+
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stderr,
+    format='%(message)s',
+)
+
+def local_var_info(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG or call_name != 'debug':
+        return event_dict
+    caller = inspect.stack()[3]
+    event_dict.update({
+        'locals': caller[0].f_locals,
+    })
+    return event_dict
+
+def _unroll_odict(od):
+    """Takes an ordereddict and rebuilds it as a regular dict
+
+    Only used in DEBUG mode, because logs below DEBUG are encoded
+    as JSON anyway."""
+    cleaned = {}
+    for key, value in od.items():
+        if isinstance(value, ordereddict.ordereddict):
+            cleaned[key] = _unroll_odict(value)
+        else:
+            cleaned[key] = value
+    return cleaned
+
+def unorder_dict(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        return event_dict
+    for key, value in event_dict.items():
+        if isinstance(value, ordereddict.ordereddict):
+            event_dict[key] = _unroll_odict(value)
+    return event_dict
+
+def add_caller_info(logger, call_name, event_dict):
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        return event_dict
+    elif event_dict.get('terse'):
+        event_dict.pop('terse')
+        return event_dict
+    caller = inspect.stack()[3]
+
+    if 'caller_func' not in event_dict:
+        event_dict['caller_func'] = caller[0].f_code.co_name
+    if 'caller_file' not in event_dict:
+        event_dict['caller_file'] = caller[1]
+    if 'caller_line' not in event_dict:
+        event_dict['caller_line'] = caller[2]
+
+    return event_dict
+
+def alternate_dev_formatter():
+    debugging = ConsoleRenderer()
+    standard = JSONRenderer(sort_keys=True)
+    def with_memoized_loggers(logger, call_name, event_dict):
+        if logger.getEffectiveLevel() > logging.DEBUG:
+            return standard(logger, call_name, event_dict)
+        return debugging(logger, call_name, event_dict)
+    return with_memoized_loggers
+
+def getLogger(name):
+    return wrap_logger(
+        logging.getLogger(name),
+        processors=[
+            filter_by_level,
+            add_caller_info,
+            #local_var_info,
+            unorder_dict,
+            TimeStamper(fmt="ISO", utc=False),
+            format_exc_info,
+            alternate_dev_formatter()
+        ]
+    )

--- a/container/visibility.py
+++ b/container/visibility.py
@@ -11,7 +11,8 @@ from ruamel import ordereddict
 from structlog import wrap_logger
 from structlog.processors import JSONRenderer
 from structlog.dev import ConsoleRenderer
-from structlog.stdlib import filter_by_level
+from structlog.stdlib import filter_by_level, add_logger_name
+from structlog.stdlib import BoundLogger, PositionalArgumentsFormatter
 from structlog.processors import format_exc_info, TimeStamper
 
 logging.basicConfig(
@@ -67,12 +68,15 @@ def getLogger(name):
     return wrap_logger(
         logging.getLogger(name),
         processors=[
+            PositionalArgumentsFormatter(),
             filter_by_level,
+            add_logger_name,
             add_caller_info,
             #local_var_info,
             unorder_dict,
             TimeStamper(fmt="ISO", utc=False),
             format_exc_info,
             alternate_dev_formatter()
-        ]
+        ],
+        wrapper_class=BoundLogger,
     )

--- a/container/visibility.py
+++ b/container/visibility.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import inspect
 import logging
 import sys
+import json
 
 from ruamel import ordereddict
 
@@ -28,25 +29,12 @@ def local_var_info(logger, call_name, event_dict):
     })
     return event_dict
 
-def _unroll_odict(od):
-    """Takes an ordereddict and rebuilds it as a regular dict
-
-    Only used in DEBUG mode, because logs below DEBUG are encoded
-    as JSON anyway."""
-    cleaned = {}
-    for key, value in od.items():
-        if isinstance(value, ordereddict.ordereddict):
-            cleaned[key] = _unroll_odict(value)
-        else:
-            cleaned[key] = value
-    return cleaned
-
 def unorder_dict(logger, call_name, event_dict):
     if logger.getEffectiveLevel() > logging.DEBUG:
         return event_dict
     for key, value in event_dict.items():
         if isinstance(value, ordereddict.ordereddict):
-            event_dict[key] = _unroll_odict(value)
+            event_dict[key] = json.dumps(value)
     return event_dict
 
 def add_caller_info(logger, call_name, event_dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML>=3.11
 six
 requests
 ruamel.yaml
+structlog[dev]

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
         'pytest>=3',
         'docker>=2.1'
     ],
+    extras_require={
+        'docker': ['docker>=2.1'],
+    },
     dependency_links=[
         'git+https//github.com/ansible/ansible'
     ],


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This change migrates much of the project logging to the [structlog](https://structlog.readthedocs.io/en/stable/) library to help make information coming from different places inside ansible-container, and make it easier to attach extra information to logs. For example, as a dev you can make your logs more useful by writing code like `log.info("Pulling dependent images", images=["f102e1f66597", "4a07b2d390de", "88e169ea8f46"])`. For users in debug mode, that will be colorized with the message in bold and the extra data in a less obtrusive color for easy skimming. In normal usage, all logs will be dumped to JSON and output so they can be consumed by other tools. 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
2017-03-20T11:04:29.077045 Loading engine capabilities    caller_file='/home/ryansb/code/ansible-container/container/conductor/loader.py' caller_func='load_engine' caller_line=12 capabilities=['RUN'] engine='docker' 
2017-03-20T11:04:29.104287 Service not running, will be started by `run` command [container.core] caller_file='/home/ryansb/code/ansible-container/container/core.py' caller_func='cmdrun_run' caller_line=175 service='redis'
2017-03-20T11:04:29.133237 Call: Engine.run_conductor     args=('run', {'services': ordereddict([('redis', ordereddict([('from', 'centos:7'), ('roles', ['j00bar.redis-container'])]))]), 'version': '2', 'defaults': ordereddict([])}, '/home/ryansb/code/ansible-container/test/mk-ii', {'with_volumes': [], 'remove_orphans': False, 'service': [], 'with_variables': [], 'selinux': True, 'subcommand': 'run', 'devel': True, 'roles
_path': None, 'production': False, 'debug': True, 'detached': False}) caller_file='/home/ryansb/code/ansible-container/container/conductor/docker/engine.py' caller_func='Engine.run_conductor' caller_line=167 kwar
gs={}
```
