### PR TITLE
Env lookup always returns a string

### DIFF
--- a/test/roles/validate-build-and-import/tasks/main.yml
+++ b/test/roles/validate-build-and-import/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Make temporary workspace
   tempfile:
-    path: "{{ lookup('env', 'TMPDIR')|default(omit) }}"
+    path: "{{ lookup('env', 'TMPDIR')|default(omit, boolean=True) }}"
     state: directory
     suffix: "{{ item.name }}"
   with_items: "{{ distros }}"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
`env` lookup returns an empty string when the environment variable isn't defined, hence `path` parameter wasn't omitted and relative path was used.

The exception was:
```
docker.errors.APIError: 500 Server Error: Internal Server Error (\"create ansible.jpz85xs2ubuntu/test-ubuntu: \"ansible.jpz85xs2ubuntu/test-ubuntu\" includes invalid characters for a local volume name, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed. If you intented to pass a host directory, use absolute path\")"
```