### PR TITLE
Check environment markers before installing a dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class PlaybookAsTests(TestCommand):
 if container.ENV == 'host':
     install_reqs = parse_requirements('requirements.txt', session=False)
     setup_kwargs = dict(
-        install_requires=[str(ir.req) for ir in install_reqs],
+        install_requires=[str(ir.req) for ir in install_reqs if ir.match_markers()],
         tests_require=[
             'ansible==2.3.0.0',
             'pytest>=3',


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I encountered this problem while testing #412, environment markers should not be ignored.