### PR TITLE
Install gcc when conductor is Debian

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -48,16 +48,9 @@ class AnsibleContainerConfig(Mapping):
 
     @property
     def deployment_path(self):
-        return self.get('settings', {}).get(
-            'deployment_output_path',
-            path.normpath(
-                path.abspath(
-                    path.expanduser(
-                        path.join(self.base_path, 'ansible-deployment/')
-                    )
-                )
-            )
-        )
+        dep_path = self.get('settings', {}).get('deployment_output_path',
+                                                path.join(self.base_path, 'ansible-deployment/'))
+        return path.normpath(path.abspath(path.expanduser(dep_path)))
 
     def set_env(self, env):
         """

--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -8,7 +8,7 @@ RUN yum update -y && \
     yum clean all
 {% elif distro in ["debian", "ubuntu"] %}
 RUN apt-get update -y && \
-    apt-get install -y python2.7 git python-dev rsync libffi-dev libssl-dev python-apt && \
+    apt-get install -y gcc python2.7 git python-dev rsync libffi-dev libssl-dev python-apt && \
     cd /usr/bin && \
     ln -fs python2.7 python && \
     apt-get clean

--- a/container/templates/init/container.j2.yml
+++ b/container/templates/init/container.j2.yml
@@ -1,13 +1,13 @@
 version: "2"
 settings:
-  # The deployment_output_path is mounted to the Conductor container, so
-  # that the `run` and `deployment` commands can write generated Ansible
-  # playbooks to it.
-  # deployment_output_path: ~/ansible-deployment
   # The Conductor container does the heavy lifting, and provides a portable
   # Python runtime for building your target containers. It should be derived
   # from the same distribution as you're building your target containers with.
   conductor_base: {{ default_base }}
+
+  # The deployment_output_path is mounted to the Conductor container, and the 
+  # `run` and `deployment` commands then write generated Ansible playbooks to it.
+  # deployment_output_path: ./ansible-deployment
 
   # When using the k8s or openshift engines, use the following to authorize with the API.
   # Values set here will be passed to the Ansible modules. Any file paths will be mounted


### PR DESCRIPTION
- Installs gcc when Debian.
- Fixes `config.py` not returning a valid path when `deployment_output_path` = `./ansible-deployment`
- A little clean up in the `init/container.j2.yml` template