### PR TITLE
Fedora systems do not have or need epel-release

### DIFF
--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -3,7 +3,7 @@ ENV ANSIBLE_CONTAINER=1
 {% set distro = conductor_base.split(':')[0] %}
 {% if distro in ["fedora", "centos"] %}
 RUN yum update -y && \
-    yum install -y epel-release   && \
+    {% if distro in ["centos"] %}yum install -y epel-release && \{% endif %}
     yum install -y gcc git python-devel rsync libffi-devel openssl-devel && \
     yum clean all
 {% elif distro in ["debian", "ubuntu"] %}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Dockerfile fails to build when using Fedora as distro due to trying to install the unnecessary epel-release package.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
