### PR TITLE
Make life better for Xenial users

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Andrea De Pirro <andrea.depirro@yameveo.com>
 Erik Nelson <erik@nsk.io>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
+fignew <thomas@vorget.com>
 Trishna Guha <trishnaguha17@gmail.com>
 John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>

--- a/container/cli.py
+++ b/container/cli.py
@@ -126,15 +126,13 @@ class HostCommand(object):
                                     u'changes have been made necessitating rebuild. '
                                     u'You may disable layer caching with this flag.',
                                dest='cache', default=True)
-        subparser.add_argument('--python-interpreter', action='store',
-                               help=u'Ansible Container brings its own Python runtime '
-                                    u'into your target containers for Ansible to use. '
-                                    u'If you would like to bring your own Python runtime '
-                                    u'instead, use this to specify the path to that '
-                                    u'runtime.', dest='python_interpreter', default=None)
-        subparser.add_argument('--services', action='store',
-                               help=u'Rather than build all services, only build specific services.',
-                               nargs='+', dest='services_to_build', default=None)
+        subparser.add_argument('--use-local-python', action='store_true',
+                               help=u'Prevents Ansible Container from bringing its own Python runtime '
+                                    u'into target containers in order to run Ansible. Use when the target '
+                                    u'already has an installed Python runtime.',
+                               dest='local_python', default=False)
+        subparser.add_argument('--no-conductor-runtime', action='store_false',
+                               help=u'')
         subparser.add_argument('ansible_options', action='store',
                                help=u'Provide additional commandline arguments to '
                                     u'Ansible in executing your playbook. If you '

--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -10,6 +10,7 @@ RUN yum update -y && \
 RUN apt-get update -y && \
     apt-get install -y gcc python2.7 git python-dev rsync libffi-dev libssl-dev python-apt && \
     cd /usr/bin && \
+    rm -f lsb_release && \
     ln -fs python2.7 python && \
     apt-get clean
 {% elif distro in ["alpine"] %}

--- a/docs/rst/reference/build.rst
+++ b/docs/rst/reference/build.rst
@@ -47,11 +47,11 @@ To disable these caches and ensure a clean rebuild, use this option.
 Define one or more environment variables in the Ansible Conductor container. Format each variable as a
 key=value string.
 
-.. option:: --python-interpreter PYTHON_INTERPRETER_PATH
+.. option:: --use-local-python
 
-Ansible Container uses the Python interpreter exported from the Conductor container
-into your target images for Ansible builds. If you wish to bring your own Python
-runtime, use this option to specify the path to it.
+Ansible Container will mount the ``/usr`` volume from the conductor container into the target container as ``/_usr``,
+and use the Python runtime from ``/_usr`` to run Ansible modules. Use this option to prevent this behavior, and force
+it to use the Python runtime found locally on the target container.
 
 .. option:: ansible_options
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- Remove `lsb_release` from conductor and force Ansible to read `/etc/lsb-release`
- Replaces `--python-interpreter` with `--use-local-python` option. If True, will prevent mounting `/usr` from conductor to `/_usr` in the target. 