### PR TITLE
Conductor image: support fedora

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -670,7 +670,7 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
                 if not local_python:
                     # Use the conductor's Python runtime
                     run_kwargs['environment'] = dict(
-                         LD_LIBRARY_PATH='/_usr/lib:/_usr/local/lib',
+                         LD_LIBRARY_PATH='/_usr/lib:/_usr/lib64:/_usr/local/lib',
                          CPATH='/_usr/include:/_usr/local/include',
                          PATH='/usr/local/sbin:/usr/local/bin:'
                               '/usr/sbin:/usr/bin:/sbin:/bin:'

--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -1,9 +1,13 @@
 FROM {{ conductor_base }}
 ENV ANSIBLE_CONTAINER=1
 {% set distro = conductor_base.split(':')[0] %}
-{% if distro in ["fedora", "centos"] %}
+{% if distro in ["fedora"] %}
+RUN dnf update -y && \
+    dnf install -y gcc git python2 python2-devel rsync libffi-devel openssl-devel redhat-rpm-config python2-dnf && \
+    dnf clean all
+{% elif distro in ["centos"] %}
 RUN yum update -y && \
-    {% if distro in ["centos"] %}yum install -y epel-release && \{% endif %}
+    yum install -y epel-release && \
     yum install -y gcc git python-devel rsync libffi-devel openssl-devel && \
     yum clean all
 {% elif distro in ["debian", "ubuntu"] %}


### PR DESCRIPTION
Fedora-based conductor shoud use dnf and install additional package (redhat-rpm-config) -
its required to compile cryptography