### PR TITLE
Adds --force option to init subcommand to enable running init inside …

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -104,6 +104,10 @@ class HostCommand(object):
                                help=u'Use a project template instead of making a '
                                     u'blank project from an Ansible Container project '
                                     u'from Ansible Galaxy.')
+        subparser.add_argument('--force', '-f', action='store_true',
+                               help=u'Overrides the requirement that init be run'
+                                    u'in an empty directory, for example'
+                                    u'if a virtualenv exists in the directory.')
 
 
     def subcmd_build_parser(self, parser, subparser):

--- a/container/core.py
+++ b/container/core.py
@@ -42,7 +42,8 @@ DEFAULT_CONDUCTOR_BASE = 'centos:7'
 @host_only
 def hostcmd_init(base_path, project=None, **kwargs):
     if project:
-        if os.listdir(base_path):
+        force = kwargs.pop('force')
+        if os.listdir(base_path) and not force:
             raise AnsibleContainerAlreadyInitializedException(
                 u'The init command can only be run in an empty directory.')
         try:


### PR DESCRIPTION
…a non-empty directory.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #463 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
