### PR TITLE
Fixes builds for debian/ubuntu based images (#480)

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -668,9 +668,23 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
                 )
 
                 if not local_python:
+                    # If we're on a debian based distro, we need the correct architecture
+                    # to allow python to load dynamically loaded shared libraries
+                    extra_library_paths = ''
+                    try:
+                        architecture = subprocess.check_output(['dpkg-architecture',
+                                                                   '-qDEB_HOST_MULTIARCH'])
+                        architecture = architecture.strip()
+                        logger.debug(u'Detected architecture %s', architecture,
+                                       service=service_name, architecture=architecture)
+                        extra_library_paths = ':/_usr/lib/{0}:/_usr/local/lib/{0}'.format(architecture)
+                    except Exception:
+                        # we're not on debian/ubuntu or a system without multiarch support
+                        pass
+
                     # Use the conductor's Python runtime
                     run_kwargs['environment'] = dict(
-                         LD_LIBRARY_PATH='/_usr/lib:/_usr/lib64:/_usr/local/lib',
+                         LD_LIBRARY_PATH='/_usr/lib:/_usr/lib64:/_usr/local/lib{}'.format(extra_library_paths),
                          CPATH='/_usr/include:/_usr/local/include',
                          PATH='/usr/local/sbin:/usr/local/bin:'
                               '/usr/sbin:/usr/bin:/sbin:/bin:'

--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -12,7 +12,7 @@ RUN yum update -y && \
     yum clean all
 {% elif distro in ["debian", "ubuntu"] %}
 RUN apt-get update -y && \
-    apt-get install -y gcc python2.7 git python-dev rsync libffi-dev libssl-dev python-apt && \
+    apt-get install -y gcc python2.7 git python-dev rsync libffi-dev libssl-dev dpkg-dev python-apt && \
     cd /usr/bin && \
     rm -f lsb_release && \
     ln -fs python2.7 python && \


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
This change uses `dpkg-architecture -qDEB_HOST_MULTIARCH` to determine the current architecture and adjusts the LD_LIBRARY_PATH accordingly when running python on the container build. This requires a new package dependency in the Dockerfile, which is also added in this PR.

For an in-depth analysis check the analysis section of the referenced ticket.

Fixes #480 
