### PR TITLE
Logs init exception messages instead of clobbering them with a generi…

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -259,8 +259,8 @@ class HostCommand(object):
 
         try:
             getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
-        except exceptions.AnsibleContainerAlreadyInitializedException:
-            logger.error('Ansible Container is already initialized', exc_info=False)
+        except exceptions.AnsibleContainerAlreadyInitializedException as e:
+            logger.error('{0}'.format(e), exc_info=False)
             sys.exit(1)
         except exceptions.AnsibleContainerNotInitializedException:
             logger.error('No Ansible Container project data found - do you need to '


### PR DESCRIPTION
…c message.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #474 

The CLI no longer clobbers error messages passed to `AnsibleContainerAlreadyInitializedException` with the generic message `Ansible Container is already initialized.`

