### PR TITLE
Decode byte-string returned by base64.b64decode()

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -306,7 +306,7 @@ host_commandline = HostCommand()
 
 
 def decode_b64json(encoded_params):
-    return json.loads(base64.b64decode(encoded_params))
+    return json.loads(base64.b64decode(encoded_params).decode())
 
 
 @container.conductor_only


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Python 3.5 b64decode returns a byte-string, rather than a string.