### PR TITLE
Updates docs and starter container.yml delivered by init to match each other.

### DIFF
--- a/container/templates/init/container.j2.yml
+++ b/container/templates/init/container.j2.yml
@@ -41,17 +41,16 @@ settings:
 services: {}
   # Add your containers here, specifying the base image you want to build from.
   # To use this example, uncomment it and delete the curly braces after services key.
+  # You may need to run `docker pull ubuntu:trusty` for this to work.
 
-  # version: "2"
-  # services:
-  #   web:
-  #     from: "ubuntu:trusty"
-  #     ports:
-  #       - "80:80"
-  #     command: ["/usr/bin/dumb-init", "/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
-  #     dev_overrides:
-  #       environment:
-  #         - "DEBUG=1"
+  # web:
+  #   from: "ubuntu:trusty"
+  #   ports:
+  #     - "80:80"
+  #   command: ["/usr/bin/dumb-init", "/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+  #   dev_overrides:
+  #     environment:
+  #       - "DEBUG=1"
 registries: {}
   # Add optional registries used for deployment. For example:
   #  google:

--- a/container/templates/init/container.j2.yml
+++ b/container/templates/init/container.j2.yml
@@ -39,20 +39,19 @@ settings:
   #  display_name:
 
 services: {}
-  # Add your containers here, specifying the base image you want to build from
-  # For example:
-  #
-  # web:
-  #   from: centos:7
-  #   roles:
-  #     - apache-container
-  #   ports:
-  #     - "80:80"
-  #   command: ['/usr/bin/dumb-init', '/usr/sbin/apache2ctl', '-D', 'FOREGROUND']
-  #   dev_overrides:
-  #     environment:
-  #       - "DEBUG=1"
-  #
+  # Add your containers here, specifying the base image you want to build from.
+  # To use this example, uncomment it and delete the curly braces after services key.
+
+  # version: "2"
+  # services:
+  #   web:
+  #     from: "ubuntu:trusty"
+  #     ports:
+  #       - "80:80"
+  #     command: ["/usr/bin/dumb-init", "/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+  #     dev_overrides:
+  #       environment:
+  #         - "DEBUG=1"
 registries: {}
   # Add optional registries used for deployment. For example:
   #  google:

--- a/container/templates/init/container.j2.yml
+++ b/container/templates/init/container.j2.yml
@@ -44,7 +44,7 @@ services: {}
   # You may need to run `docker pull ubuntu:trusty` for this to work.
 
   # web:
-  #   from: "ubuntu:trusty"
+  #   from: "centos:7"
   #   ports:
   #     - "80:80"
   #   command: ["/usr/bin/dumb-init", "/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/docs/rst/getting_started.rst
+++ b/docs/rst/getting_started.rst
@@ -82,7 +82,7 @@ By way of an example, consider the below ``container.yml`` file:
     version: "2"
     services:
       web:
-        from: "ubuntu:trusty"
+        from: "centos:7"
         ports:
           - "80:80"
         command: ["/usr/bin/dumb-init", "/usr/sbin/apache2ctl", "-D", "FOREGROUND"]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #493 

The new `container.yml` delivered by `ansible-container init` matches the one in the docs and is buildable and runnable.
