### PR TITLE
Fixed urljoin bug in k8s deployment

### DIFF
--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -91,7 +91,11 @@ class K8sBaseEngine(DockerEngine):
             if local_images:
                 self.services[service_name]['image'] = image.tags[0]
             else:
-                self.services[service_name]['image'] = urljoin(urljoin(url, namespace), image.tags[0])
+                if namespace is not None:
+                    image_url = urljoin('{}/'.format(urljoin(url, namespace)), image.tags[0])
+                else:
+                    image_url = urljoin(url, image.tags[0])
+                self.services[service_name]['image'] = image_url
 
         if kwargs.get('k8s_auth'):
             self.k8s_client.set_authorization(kwargs['auth'])


### PR DESCRIPTION
The documentation shows that the registry does not require a trailing slash or the namespace. When joining URLs using urljoin if there is no trailing slash the namespace gets overwritten by the tag

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There was a bug in the way that URLs were joined using urljoin. Added a conditional to add this logic in for namespaces for k8s deployments

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #489 
