### PR TITLE
Fix for #514

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,14 +20,16 @@ Sebastien Plisson <sebastien.plisson@gmail.com>
 Gerard Braad <me@gbraad.nl>
 Evgeni Golov <evgeni@golov.de>
 Will Thames <wthames@redhat.com>
-Vadim Rutkovsky <roignac@gmail.com>
+Joseph Callen <jcpowermac@gmail.com>
 Grzegorz Nosek <root@localdomain.pl>
 Abhishek Pratap Singh <abhishek@linux.com>
+Vadim Rutkovsky <roignac@gmail.com>
 Todd Barr <tbarr@ansible.com>
 Will Refvem <wbrefvem@users.noreply.github.com>
 Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
 Ted Timmons <ted@perljam.net>
+marc-sensenich <marc-sensenich@users.noreply.github.com>
 Bruce Becker <brucellino@gmail.com>
 Evan Zeimet <evan.zeimet@cdw.com>
 John Matthews <jwmatthews@gmail.com>

--- a/container/config.py
+++ b/container/config.py
@@ -18,6 +18,7 @@ from ruamel import yaml
 import container
 if container.ENV == 'conductor':
     from ansible.template import Templar
+    from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from .exceptions import AnsibleContainerConfigException, AnsibleContainerNotInitializedException
 from .utils import get_metadata_from_role, get_defaults_from_role
 
@@ -233,6 +234,8 @@ class AnsibleContainerConductorConfig(Mapping):
             if isinstance(value, basestring):
                 # strings can be templated
                 processed[key] = templar.template(value)
+                if isinstance(processed[key], AnsibleUnsafeText):
+                    processed[key] = str(processed[key])
             elif isinstance(value, (list, dict)):
                 # if it's a dimensional structure, it's cheaper just to serialize
                 # it, treat it like a template, and then deserialize it again

--- a/container/core.py
+++ b/container/core.py
@@ -495,6 +495,7 @@ def run_playbook(playbook, engine, service_map, ansible_options='', local_python
 
         playbook_path = os.path.join(output_dir, 'playbook.yml')
         logger.debug("writing playbook to {}".format(playbook_path))
+        logger.debug("playbook", playbook=playbook)
         with open(playbook_path, 'w') as ofs:
             ofs.write(ruamel.yaml.round_trip_dump(playbook, indent=4, block_seq_indent=2, default_flow_style=False))
 

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -239,6 +239,10 @@ class Engine(BaseEngine):
             environ['DOCKER_HOST'] = 'unix:///var/run/docker.sock'
             volumes['/var/run/docker.sock'] = {'bind': '/var/run/docker.sock',
                                                'mode': 'rw'}
+        if params.get('with_variables'):
+            for var in params['with_variables']:
+                key, value = var.split('=', 1)
+                environ[key] = value
 
         if roles_path:
             environ['ANSIBLE_ROLES_PATH'] = "%s:/src/roles:/etc/ansible/roles" % roles_path

--- a/test/tests/validate_config.py
+++ b/test/tests/validate_config.py
@@ -13,6 +13,7 @@ from ansible.vars import Templar
 from ansible.playbook.role.include import RoleInclude
 from ansible.vars import VariableManager
 from ansible.parsing.dataloader import DataLoader
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 
 if 'PROJECT_PATH' not in os.environ:
     raise ImportError('PROJECT_PATH must be in the environment. You '
@@ -26,6 +27,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.var_file = os.path.join(self.project_path, 'vars.yml')
         container.ENV = 'host'
         container.config.Templar = Templar
+        container.config.AnsibleUnsafeText = AnsibleUnsafeText
         self.config = AnsibleContainerConfig(self.project_path, var_file=None, engine_name='docker')
 
     def tearDown(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Fixes #514
- Fixes `--with-variables`.  When variables are passed on the command line, they are now added to the conductor's environment
- In `config.py`, check if a template string results in an AnsibleUnsafeText object. If so, convert it to a string. This happens when a filter is used inside a template. In this particular case, it's the `lookup()` filter.