### PR TITLE
Enable image pulls, and fix role install

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -514,21 +514,25 @@ class Engine(BaseEngine):
 
         service_def = {}
         for service_name, service in self.services.items():
+            service_definition = {}
             if service.get('roles'):
                 image = self.get_latest_image_for_service(service_name)
                 if image is None:
                     raise exceptions.AnsibleContainerConductorException(
                         u"No image found for service {}, make sure you've run `ansible-container build`".format(service_name)
                     )
+                service_definition[u'image'] = image.tags[0]
             else:
-                image = self.client.images.get(service['from'])
-                if image is None:
-                    raise exceptions.AnsibleContainerConductorException(
-                        u"No image found for service {}. You probably need to pull the image from a repository.".format(service_name)
-                    )
-            service_definition = {
-                u'image': image.tags[0],
-            }
+                try:
+                  image = self.client.images.get(service['from'])
+                except docker.errors.ImageNotFound:
+                    logger.warning(u"Image {} for service {} not found. "
+                                   u"Will attempt to pull from {}".format(service['from'], service_name,
+                                                                          self.registry_name))
+                if image:
+                    service_definition[u'image'] = image.tags[0]
+                else:
+                    service_definition[u'image'] = service['from']
             for extra in self.COMPOSE_WHITELIST:
                 if extra in service:
                     service_definition[extra] = service[extra]

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -519,16 +519,17 @@ class Engine(BaseEngine):
                 image = self.get_latest_image_for_service(service_name)
                 if image is None:
                     raise exceptions.AnsibleContainerConductorException(
-                        u"No image found for service {}, make sure you've run `ansible-container build`".format(service_name)
+                        u"No image found for service {}, make sure you've run `ansible-container "
+                        u"build`".format(service_name)
                     )
                 service_definition[u'image'] = image.tags[0]
             else:
                 try:
                   image = self.client.images.get(service['from'])
                 except docker.errors.ImageNotFound:
+                    image = None
                     logger.warning(u"Image {} for service {} not found. "
-                                   u"Will attempt to pull from {}".format(service['from'], service_name,
-                                                                          self.registry_name))
+                                   u"An attempt will be made to pull it.".format(service['from'], service_name))
                 if image:
                     service_definition[u'image'] = image.tags[0]
                 else:

--- a/container/utils/galaxy.py
+++ b/container/utils/galaxy.py
@@ -104,9 +104,9 @@ class AnsibleContainerGalaxy(object):
             return None
         logger.debug('Role %s is containerized', role_obj)
         try:
-            assert isinstance(snippet, dict) and len(snippet) == 1
+            assert isinstance(snippet, dict) and len(snippet) > 0
         except AssertionError:
-            logger.exception('Role %s container.yml is malformed' % role_obj.namej)
+            logger.exception('Role %s container.yml is malformed' % role_obj.name)
             return None
         return snippet
 
@@ -137,14 +137,13 @@ class AnsibleContainerGalaxy(object):
         if not container_yml['services']:
             container_yml['services'] = {}
         services = container_yml['services']
-        # The snippet should be a dictionary with one key
-        new_service_key = snippet.keys()[0]
+        new_service_key = role_obj.name
         if new_service_key in services:
             raise exceptions.AnsibleContainerGalaxyRoleException(
                 'Role defines service %s, but container.yml already has a service with this name' % new_service_key)
 
         # Add role name to the service's list of roles
-        services[new_service_key] = snippet[new_service_key]
+        services[new_service_key] = {}
         if not services[new_service_key].get('roles'):
             services[new_service_key]['roles'] = []
         if role_obj.name not in services[new_service_key]['roles']:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- If a service does not have a `roles` directive, then pass the `from` value as the `image` to Ansible playbook that runs the application, and allow the `docker_service` module to pull the image.
- Warns that it will attempt to pull the image
- Fixes parsing of `meta/container.yml`.
- Adds a new service with the same name as the role, since the meta data no longer contains a service name.
- Only adds a `roles` directive to the new service, ignoring all other directives