### PR TITLE
For volume src path, normalize and expand user vars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,9 +13,9 @@ Dusty Mabe <dusty@dustymabe.com>
 Dylan Silva <thaumos@users.noreply.github.com>
 Fabian von Feilitzsch <fabianvf@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
+Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
 Will Refvem <wbrefvem@gmail.com>
-Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Sebastien Plisson <sebastien.plisson@gmail.com>
 Gerard Braad <me@gbraad.nl>
 Evgeni Golov <evgeni@golov.de>
@@ -41,10 +41,10 @@ Ali Asad Lotia <ali.asad.lotia@gmail.com>
 Chrrrles Paul <chrrrles@users.noreply.github.com>
 Andrea De Pirro <andrea.depirro@yameveo.com>
 Erik Nelson <erik@nsk.io>
-Aaron Cowdin <aaronthebaron@users.noreply.github.com>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
 fignew <thomas@vorget.com>
+Aaron Cowdin <aaronthebaron@users.noreply.github.com>
 John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>
 grimmjow <ryanbrown.dev@gmail.com>

--- a/container/cli.py
+++ b/container/cli.py
@@ -68,7 +68,7 @@ class HostCommand(object):
                                         u'Specify volumes as strings using the Docker volume format.',
                                    default=[])
             subparser.add_argument('--with-variables', '-e', action='store', nargs='+',
-                                   help=u'Define one or more environment variables in the Ansible '
+                                   help=u'Define one or more environment variables in the '
                                         u'Conductor. Format each variable as a key=value string.',
                                    default=[])
             subparser.add_argument('--roles-path', action='store', default=None,

--- a/container/cli.py
+++ b/container/cli.py
@@ -18,6 +18,7 @@ from . import core
 from . import exceptions
 from container.config import AnsibleContainerConductorConfig
 
+from collections import OrderedDict
 from logging import config
 LOGGING = {
         'version': 1,
@@ -306,7 +307,8 @@ host_commandline = HostCommand()
 
 
 def decode_b64json(encoded_params):
-    return json.loads(base64.b64decode(encoded_params).decode())
+    # Using object_pairs_hook to preserve the original order of any dictionaries
+    return json.loads(base64.b64decode(encoded_params).decode(), object_pairs_hook=OrderedDict)
 
 
 @container.conductor_only

--- a/container/config.py
+++ b/container/config.py
@@ -79,6 +79,14 @@ class AnsibleContainerConfig(Mapping):
                 dev_overrides = service_config.pop('dev_overrides', {})
                 if env == 'dev':
                     service_config.update(dev_overrides)
+            if 'volumes' in service_config:
+                # Expand ~, ${HOME}, ${PWD}, etc. found in the volume src path
+                updated_volumes = []
+                for volume in service_config['volumes']:
+                    vol_pieces = volume.split(':')
+                    vol_pieces[0] = path.normpath(path.abspath(path.expanduser(vol_pieces[0])))
+                    updated_volumes.append(':'.join(vol_pieces))
+                service_config['volumes'] = updated_volumes
             if self.engine_name not in ('openshift', 'k8s'):
                 if 'k8s' in service_config:
                     del service_config['k8s']

--- a/container/config.py
+++ b/container/config.py
@@ -12,7 +12,7 @@ import json
 import re
 import six
 
-from collections import Mapping
+from collections import Mapping, OrderedDict
 from ruamel import yaml
 
 import container
@@ -84,7 +84,7 @@ class AnsibleContainerConfig(Mapping):
                 updated_volumes = []
                 for volume in service_config['volumes']:
                     vol_pieces = volume.split(':')
-                    vol_pieces[0] = path.normpath(path.abspath(path.expanduser(vol_pieces[0])))
+                    vol_pieces[0] = path.normpath(path.expandvars(path.expanduser(vol_pieces[0])))
                     updated_volumes.append(':'.join(vol_pieces))
                 service_config['volumes'] = updated_volumes
             if self.engine_name not in ('openshift', 'k8s'):
@@ -285,6 +285,16 @@ class AnsibleContainerConductorConfig(Mapping):
                 # have that filled in with the project path
                 service_data['volumes'][idx] = re.sub(r'\$(PWD|\{PWD\})', self._config['settings'].get('pwd'),
                                                       service_data['volumes'][idx])
+            if service_data.get('roles'):
+                # Convert ordereddict to dict
+                updated_roles = []
+                for role in service_data['roles']:
+                    if isinstance(role, OrderedDict):
+                        updated_roles.append({k: v for k, v in role.iteritems()})
+                    else:
+                        updated_roles.append(role)
+                service_data['roles'] = updated_roles
+
             for role_spec in service_data.get('roles', []):
                 if isinstance(role_spec, dict):
                     # A role with parameters to run it with

--- a/container/core.py
+++ b/container/core.py
@@ -672,7 +672,7 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
                             'done"',
                     entrypoint=[],
                     privileged=True,
-                    volumes = dict()
+                    volumes=dict()
                 )
 
                 if service.get('volumes'):

--- a/container/core.py
+++ b/container/core.py
@@ -162,7 +162,6 @@ def hostcmd_build(base_path, project_name, engine_name, var_file=None,
     if kwargs.get('save_conductor_container'):
         # give precedence to CLI option
         save_container = True
-
     engine_obj.await_conductor_command(
         'build', dict(config), base_path, kwargs, save_container=save_container)
 
@@ -621,7 +620,6 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
     engine = load_engine(['BUILD'], engine_name, project_name, services, **kwargs)
     logger.info(u'%s integration engine loaded. Build starting.',
         engine.display_name, project=project_name)
-
     services_to_build = kwargs.get('services_to_build') or services.keys()
     for service_name, service in services.items():
         if service_name not in services_to_build:

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -99,9 +99,9 @@ class Engine(BaseEngine):
 
     COMPOSE_WHITELIST = (
         'links', 'depends_on', 'cap_add', 'cap_drop', 'command', 'devices',
-        'dns', 'dns_opt', 'tmpfs', 'entrypoint', 'environment', 'external_links', 'labels',
-        'links', 'logging', 'log_opt', 'networks', 'network_mode',
-        'pids_limit', 'ports', 'security_opt', 'stop_grace_period',
+        'dns', 'dns_opt', 'tmpfs', 'entrypoint', 'environment', 'expose',
+        'external_links', 'labels', 'links', 'logging', 'log_opt', 'networks',
+        'network_mode', 'pids_limit', 'ports', 'security_opt', 'stop_grace_period',
         'stop_signal', 'sysctls', 'ulimits', 'userns_mode', 'volumes',
         'volume_driver', 'volumes_from', 'cpu_shares', 'cpu_quota', 'cpuset',
         'domainname', 'hostname', 'ipc', 'mac_address', 'mem_limit',
@@ -207,7 +207,6 @@ class Engine(BaseEngine):
             raise exceptions.AnsibleContainerConductorException(
                     u"Conductor container can't be found. Run "
                     u"`ansible-container build` first")
-
         serialized_params = base64.b64encode(json.dumps(params).encode("utf-8")).decode()
         serialized_config = base64.b64encode(json.dumps(config).encode("utf-8")).decode()
 

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -215,12 +215,13 @@ class Engine(BaseEngine):
             volumes = {}
 
         if params.get('with_volumes'):
-          for volume in params.get('with_volumes'):
-              volume_parts = volume.split(':')
-              volumes[volume_parts[0]] = {
-                  'bind': volume_parts[1] if len(volume_parts) > 1 else volume_parts[0],
-                  'mode': volume_parts[2] if len(volume_parts) > 2 else 'rw'
-              }
+            for volume in params.get('with_volumes'):
+                volume_parts = volume.split(':')
+                volume_parts[0] = os.path.normpath(os.path.abspath(os.path.expanduser(volume_parts[0])))
+                volumes[volume_parts[0]] = {
+                    'bind': volume_parts[1] if len(volume_parts) > 1 else volume_parts[0],
+                    'mode': volume_parts[2] if len(volume_parts) > 2 else 'rw'
+                }
 
         permissions = 'ro' if command != 'install' else 'rw'
         volumes[base_path] = {'bind': '/src', 'mode': permissions}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- Whenever we're working with volumes, we should account for user variables and `~` in the src path.
- Whitelist `expose` directive
- Build services in the expected order, top->bottom.