### PR TITLE
Fix broken playbooks

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -185,8 +185,6 @@ def hostcmd_deploy(base_path, project_name, engine_name, var_file=None,
     }
     if config.get('settings', {}).get('k8s_auth'):
         params['k8s_auth'] = config['settings']['k8s_auth']
-    if config.get('volumes'):
-        params['volumes'] = config['volumes']
     if kwargs:
         params.update(kwargs)
 
@@ -223,8 +221,6 @@ def hostcmd_run(base_path, project_name, engine_name, var_file=None, cache=True,
     }
     if config.get('settings', {}).get('k8s_auth'):
         params['k8s_auth'] = config['settings']['k8s_auth']
-    if config.get('volumes'):
-        params['volumes'] = config['volumes']
     if kwargs:
         params.update(kwargs)
 
@@ -254,8 +250,6 @@ def hostcmd_destroy(base_path, project_name, engine_name, var_file=None, cache=T
     }
     if config.get('settings', {}).get('k8s_auth'):
         params['k8s_auth'] = config['settings']['k8s_auth']
-    if config.get('volumes'):
-        params['volumes'] = config['volumes']
     if kwargs:
         params.update(kwargs)
     params.update(kwargs)
@@ -279,8 +273,6 @@ def hostcmd_stop(base_path, project_name, engine_name, force=False, services=[],
     }
     if config.get('settings', {}).get('k8s_auth'):
         params['k8s_auth'] = config['settings']['k8s_auth']
-    if config.get('volumes'):
-        params['volumes'] = config['volumes']
     if kwargs:
         params.update(kwargs)
     params.update(kwargs)
@@ -304,8 +296,6 @@ def hostcmd_restart(base_path, project_name, engine_name, force=False, services=
     }
     if config.get('settings', {}).get('k8s_auth'):
         params['k8s_auth'] = config['settings']['k8s_auth']
-    if config.get('volumes'):
-        params['volumes'] = config['volumes']
     if kwargs:
         params.update(kwargs)
     params.update(kwargs)
@@ -753,8 +743,10 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
 @conductor_only
 def conductorcmd_run(engine_name, project_name, services, **kwargs):
     engine = load_engine(['RUN'], engine_name, project_name, services, **kwargs)
+
     logger.info(u'Engine integration loaded. Preparing run.',
                 engine=engine.display_name)
+
     engine.containers_built_for_services(
         [service for service, service_desc in services.items()
          if service_desc.get('roles')])

--- a/container/engine.py
+++ b/container/engine.py
@@ -38,7 +38,7 @@ class BaseEngine(object):
         self.services = services
         self.debug = debug
         self.selinux = selinux
-        self.volumes = kwargs.pop('volumes', None)
+        self.volumes = kwargs.pop('volume_data', None)
 
     @property
     def display_name(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
After fixing the service order returned by the decoded configuration in cli.py, the `run` playbook broke. For some reason ordered dictionaries are being returned as arrays. Rather than fight with YAML output, removing unnecessary ordered dictionaries.