### PR TITLE
#535 BugFix - Fixing --with-volumes for stop and destroy

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -64,17 +64,17 @@ class HostCommand(object):
                           }
 
     def subcmd_common_parsers(self, parser, subparser, cmd):
-        if cmd in ('build', 'run', 'deploy', 'push', 'stop', 'destroy'):
+        if cmd in ('build', 'run', 'deploy', 'push', 'restart', 'stop', 'destroy'):
             subparser.add_argument('--with-volumes', '-v', action='store', nargs='+',
                                    help=u'Mount one or more volumes to the Conductor. '
                                         u'Specify volumes as strings using the Docker volume format.',
                                    default=[])
-
-        if cmd in ('build', 'run', 'deploy', 'push'):
             subparser.add_argument('--with-variables', '-e', action='store', nargs='+',
                                    help=u'Define one or more environment variables in the '
                                         u'Conductor. Format each variable as a key=value string.',
                                    default=[])
+
+        if cmd in ('build', 'run', 'deploy', 'push'):
             subparser.add_argument('--roles-path', action='store', default=None,
                                    help=u'Specify a local path containing roles you want to '
                                         u'use in the Conductor.')
@@ -188,6 +188,7 @@ class HostCommand(object):
         subparser.add_argument('service', action='store',
                                help=u'The specific services you want to restart',
                                nargs='*')
+        self.subcmd_common_parsers(parser, subparser, 'restart')
 
     def subcmd_destroy_parser(self, parser, subparser):
         self.subcmd_common_parsers(parser, subparser, 'destroy')

--- a/container/cli.py
+++ b/container/cli.py
@@ -64,11 +64,13 @@ class HostCommand(object):
                           }
 
     def subcmd_common_parsers(self, parser, subparser, cmd):
-        if cmd in ('build', 'run', 'deploy', 'push'):
+        if cmd in ('build', 'run', 'deploy', 'push', 'stop', 'destroy'):
             subparser.add_argument('--with-volumes', '-v', action='store', nargs='+',
                                    help=u'Mount one or more volumes to the Conductor. '
                                         u'Specify volumes as strings using the Docker volume format.',
                                    default=[])
+
+        if cmd in ('build', 'run', 'deploy', 'push'):
             subparser.add_argument('--with-variables', '-e', action='store', nargs='+',
                                    help=u'Define one or more environment variables in the '
                                         u'Conductor. Format each variable as a key=value string.',
@@ -179,6 +181,8 @@ class HostCommand(object):
         subparser.add_argument('-f', '--force', action='store_true',
                                help=u'Force stop running containers',
                                dest='force')
+        self.subcmd_common_parsers(parser, subparser, 'stop')
+
 
     def subcmd_restart_parser(self, parser, subparser):
         subparser.add_argument('service', action='store',
@@ -186,7 +190,7 @@ class HostCommand(object):
                                nargs='*')
 
     def subcmd_destroy_parser(self, parser, subparser):
-        pass
+        self.subcmd_common_parsers(parser, subparser, 'destroy')
 
     def subcmd_help_parser(self, parser, subparser):
         return


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The --with-volumes option should be usable with `stop` and `destroy` commands as ansible.cfg is taken in account when those commands are invoked .

I am using Ansible with vault. The vault file is actually a shell script that relies on (credstash)[https://github.com/fugue/credstash]:

```
# ansible.cfg
 [defaults]
 vault_password_file = get-vault-key.sh
```

```
# get-vault-key.sh
 #!/usr/bin/env bash
 
 ENV_DATA=./env-data
  
 if [ -f ${ENV_DATA} ]
 then
   . "${ENV_DATA}"
 else
   exit 1
 fi
 
 credstash -t ${REGION}-CredStash-GumRef-${TEAM} get ansible-vault-key
```

We are grabbing the ansible vault secret from AWS DynamoDB so we need AWS cli credentials to be mounted in the conductor container. In production (Jenkins CI/CD) we do not have issues with AWS credentials because we are using IAM roles. But on a developer laptop we lose the ability to  `stop` and `destroy` an ansible container project.

Here is the way I invoke the build on a project:
```
 ansible-container build --with-volumes \
     /home/florian/workspace/gumref-demo:/gumref-demo \
     /home/florian/.aws:/root/.aws
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

_Before the change:_
```
### With --with-volumes:

usage: ansible-container [-h] [--debug] [--devel] [--engine ENGINE_NAME]
                         [--project-path BASE_PATH]
                         [--project-name PROJECT_NAME] [--var-file VAR_FILE]
                         [--no-selinux]
                         {run,help,deploy,stop,destroy,restart,init,version,build,install,push,import}
                         ...
ansible-container: error: unrecognized arguments: --with-volumes

### And without --with-volumes:

(gumref) 00:45:23-florian~/workspace/gumref/web/gumref-demo (master)$  ansible-container stop 
Parsing conductor CLI args.
Engine integration loaded. Preparing to stop all containers.	engine=Docker™ daemon
mount: warning: /home/florian/workspace/gumref/web/gumref-demo/ansible-deployment/files seems to be mounted read-only.
mount: warning: /home/florian/workspace/gumref/web/gumref-demo/ansible-deployment/templates seems to be mounted read-only.
Traceback (most recent call last):
  File "/usr/local/bin/credstash", line 11, in <module>
    load_entry_point('credstash==1.13.2', 'console_scripts', 'credstash')()
  File "/usr/local/bin/credstash.py", line 805, in main
    getSecretAction(args, region, **session_params)
  File "/usr/local/bin/credstash.py", line 244, in func_wrapper
    return func(*args, **kwargs)
  File "/usr/local/bin/credstash.py", line 407, in getSecretAction
    **session_params))
  File "/usr/local/bin/credstash.py", line 436, in getSecret
    KeyConditionExpression=boto3.dynamodb.conditions.Key("name").eq(name))
  File "/usr/local/lib/python2.7/dist-packages/boto3/resources/factory.py", line 520, in do_action
    response = action(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/boto3/resources/action.py", line 83, in __call__
    response = getattr(parent.meta.client, operation_name)(**params)
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 253, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 544, in _make_api_call
    operation_model, request_dict)
  File "/usr/local/lib/python2.7/dist-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/usr/local/lib/python2.7/dist-packages/botocore/endpoint.py", line 166, in _send_request
    request = self.create_request(request_dict, operation_model)
  File "/usr/local/lib/python2.7/dist-packages/botocore/endpoint.py", line 150, in create_request
    operation_name=operation_model.name)
  File "/usr/local/lib/python2.7/dist-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/signers.py", line 90, in handler
    return self.sign(operation_name, request)
  File "/usr/local/lib/python2.7/dist-packages/botocore/signers.py", line 154, in sign
    auth.add_auth(request)
  File "/usr/local/lib/python2.7/dist-packages/botocore/auth.py", line 339, in add_auth
    raise NoCredentialsError
botocore.exceptions.NoCredentialsError: Unable to locate credentials
ERROR! Vault password script /src/get-vault-key.sh returned non-zero (1): None
All services stopped.	playbook_rc=1
Conductor terminated. Cleaning up.	command_rc=0 conductor_id=5f07f1d4f690dc2202409aba30ac6a2154b0928536eab41962fdb14543c1a423 save_container=False

```

_After the change:_
```
(gumref) 00:38:44-florian~/workspace/gumref/web/gumref-demo (master)$  ansible-container stop --with-volumes /home/florian/workspace/gumref-demo:/gumref-demo /home/florian/.aws:/root/.aws
Parsing conductor CLI args.
Engine integration loaded. Preparing to stop all containers.	engine=Docker™ daemon
mount: warning: /home/florian/workspace/gumref/web/gumref-demo/ansible-deployment/files seems to be mounted read-only.
mount: warning: /home/florian/workspace/gumref/web/gumref-demo/ansible-deployment/templates seems to be mounted read-only.

PLAY [localhost] ***************************************************************

TASK [docker_service] **********************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0

All services stopped.	playbook_rc=0
Conductor terminated. Cleaning up.	command_rc=0 conductor_id=c76adaf8613b0c5c5d90ddc63439564ed8910166d15edd610ff0d2f4a2a5893d save_container=False

```
