### PR TITLE
Fixes two errors found in running deploy

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -76,7 +76,6 @@ class BaseAnsibleContainerConfig(Mapping):
         return os.path.basename(self.base_path)
 
     @property
-    @abstractproperty
     def image_namespace(self):
         # When pushing images or deploying, we need to know the default namespace
         return self.project_name

--- a/container/openshift/config.py
+++ b/container/openshift/config.py
@@ -16,4 +16,4 @@ class AnsibleContainerConfig(K8sBaseConfig):
         return super(AnsibleContainerConfig, self).image_namespace
 
     def set_env(self, env):
-        super(AnsibleContainerConfig, self).set_env()
+        super(AnsibleContainerConfig, self).set_env(env)


### PR DESCRIPTION
TypeError: set_env() takes exactly 2 arguments (1 given)
TypeError: 'abstractproperty' object is not callable

##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Found the following two issues while testing deploy after https://github.com/ansible/ansible-container/pull/532 was merged.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Traceback (most recent call last):
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/cli.py", line 264, in __call__
    getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/core.py", line 185, in hostcmd_deploy
    url, namespace = push_images(base_path, config.image_namespace, engine_obj, config,
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/openshift/config.py", line 16, in image_namespace
    return super(AnsibleContainerConfig, self).image_namespace
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/k8s/base_config.py", line 15, in image_namespace
    namespace = super(K8sBaseConfig, self).image_namespace
TypeError: 'abstractproperty' object is not callable
```

```
Traceback (most recent call last):
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/cli.py", line 264, in __call__
    getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/core.py", line 167, in hostcmd_deploy
    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/utils/__init__.py", line 48, in get_config
    return mod.AnsibleContainerConfig(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/config.py", line 60, in __init__
    self.set_env('prod')
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/openshift/config.py", line 19, in set_env
    super(AnsibleContainerConfig, self).set_env()
TypeError: set_env() takes exactly 2 arguments (1 given)
```
