### PR TITLE
Fix key error when specifying absent services

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -118,7 +118,7 @@ class BaseAnsibleContainerConfig(Mapping):
 
             for key in service_config:
                 if key in self.remove_engines:
-                    del self._config[service][key]
+                    del config['services'][service][key]
 
         # Insure settings['pwd'] = base_path. Will be used later by conductor to resolve $PWD in volumes.
         if config.get('settings', None) is None:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
I ran into this error on latest develop by having the following in my `container.yml`:

```
services:
  foreman-base:
    from: centos:7
    roles:
      - epel-repositories
      - role: puppet-repositories
        puppet_repositories_version: 4
      - foreman-repositories
      - katello-repositories
      - foreman
    openshift:
      state: absent
```

```
ERROR	Unknown exception	
Traceback (most recent call last):
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/cli.py", line 264, in __call__
    getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/core.py", line 129, in hostcmd_build
    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/utils/__init__.py", line 48, in get_config
    return mod.AnsibleContainerConfig(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/config.py", line 60, in __init__
    self.set_env('prod')
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/docker/config.py", line 20, in set_env
    super(AnsibleContainerConfig, self).set_env(env)
  File "/home/ehelms/workspace/openshift/forklift/openshift/.tmp/ansible-container/container/config.py", line 122, in set_env
    del self._config[service][key]
KeyError: 'foreman-base'
```
