### PR TITLE
Fixes images_namespace property

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ John Matthews <jwmatthews@gmail.com>
 Sean Summers <ssummer3@nd.edu>
 Alex Yanchenko <alex@yanchenko.com>
 Balazs Zagyvai <github.zagyi@spamgourmet.com>
+Eric D Helms <eric.d.helms@gmail.com>
 Trishna Guha <trishnaguha17@gmail.com>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 szinck1 <szinck@gmail.com>

--- a/container/config.py
+++ b/container/config.py
@@ -79,7 +79,7 @@ class BaseAnsibleContainerConfig(Mapping):
     @abstractproperty
     def image_namespace(self):
         # When pushing images or deploying, we need to know the default namespace
-        return self.project_name
+        pass
 
     @abstractmethod
     def set_env(self, env):
@@ -116,9 +116,9 @@ class BaseAnsibleContainerConfig(Mapping):
                     updated_volumes.append(':'.join(vol_pieces))
                 service_config['volumes'] = updated_volumes
 
-            for key in service_config:
-                if key in self.remove_engines:
-                    del config['services'][service][key]
+            for engine_name in self.remove_engines:
+                if engine_name in service_config:
+                    del service_config[engine_name]
 
         # Insure settings['pwd'] = base_path. Will be used later by conductor to resolve $PWD in volumes.
         if config.get('settings', None) is None:

--- a/container/docker/config.py
+++ b/container/docker/config.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 class AnsibleContainerConfig(BaseAnsibleContainerConfig):
     @property
     def image_namespace(self):
-        return super(AnsibleContainerConfig, self).image_namespace
+        return self.project_name
 
     def set_env(self, env):
         super(AnsibleContainerConfig, self).set_env(env)

--- a/container/k8s/base_config.py
+++ b/container/k8s/base_config.py
@@ -12,7 +12,7 @@ class K8sBaseConfig(BaseAnsibleContainerConfig):
 
     @property
     def image_namespace(self):
-        namespace = super(K8sBaseConfig, self).image_namespace
+        namespace = self.project_name
         if self._config.get('settings', {}).get('k8s_namespace', {}).get('name'):
             namespace = self._config['settings']['k8s_namespace']['name']
         return namespace

--- a/container/openshift/config.py
+++ b/container/openshift/config.py
@@ -16,4 +16,4 @@ class AnsibleContainerConfig(K8sBaseConfig):
         return super(AnsibleContainerConfig, self).image_namespace
 
     def set_env(self, env):
-        super(AnsibleContainerConfig, self).set_env()
+        super(AnsibleContainerConfig, self).set_env(env)

--- a/container/templates/init/container.j2.yml
+++ b/container/templates/init/container.j2.yml
@@ -19,7 +19,7 @@ settings:
   #k8s_auth:
     # path to a K8s config file
     #config_file:
-    # name of a context found within the config.json file
+    # name of a context found within the config file
     #context:
     # URL for accessing the K8s API
     #host:
@@ -31,7 +31,7 @@ settings:
     #cert_file:
     # Path to a key file
     #key_file:
-    #boolean, indicating if SSL certs should be validated
+    # boolean, indicating if SSL certs should be validated
     #verify_ssl:
 
   # When using the k8s or openshift engines, use the following to set the namespace.


### PR DESCRIPTION
Replaces #533
- Preserves @abstractproperty while fixing `TypeError: 'abstractproperty' object is not callable`
- Clean up of the `container.yml` template used by `init`
- Fixes bug regarding modification of dict that's being iterated in base config.set_env()
