### PR TITLE
WIP - Add value_from Option for Environment Variables

### DIFF
--- a/container/k8s/base_deploy.py
+++ b/container/k8s/base_deploy.py
@@ -528,17 +528,20 @@ class K8sBaseDeploy(object):
 
     @staticmethod
     def expand_env_vars(env_variables):
-        """ Convert service environment attribute into dictionary of name/value pairs. """
+        """ Convert service environment attribute into dictionary of name/value pairs or mapping to value_from. """
         results = []
         if isinstance(env_variables, dict):
             results = [{'name': x, 'value': env_variables[x]} for x in list(env_variables.keys())]
         elif isinstance(env_variables, list):
             for evar in env_variables:
-                parts = evar.split('=', 1)
-                if len(parts) == 1:
-                    results.append({'name': parts[0], 'value': None})
-                elif len(parts) == 2:
-                    results.append({'name': parts[0], 'value': parts[1]})
+                if isinstance(evar, CommentedMap) and 'value_from' in evar:
+                    results.append({'name': evar.get('name'), 'valueFrom': evar.get('value_from')})
+                else:
+                    parts = evar.split('=', 1)
+                    if len(parts) == 1:
+                        results.append({'name': parts[0], 'value': None})
+                    elif len(parts) == 2:
+                        results.append({'name': parts[0], 'value': parts[1]})
         return results
 
     @staticmethod


### PR DESCRIPTION
This enables the value_from attribute to be added to the environment when deploying with k8s to grab environment variables from ConfigMaps

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The expansion of the environment variables allows for valueFrom to be mapped to value_from to read from ConfigMaps

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

