### PR TITLE
Correctly pre-seed volumes during build. Fixes #555.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,12 +1,12 @@
 Ansible Container has been contribued to by the following authors:
 This list is automatically generated - please file an issue for corrections)
 
-Joshua "jag" Ginsberg <jag@ansible.com>
 Chris Houseknecht <chouseknecht@ansible.com>
+Joshua "jag" Ginsberg <jag@ansible.com>
 Ryan Brown <sb@ryansb.com>
 Shubham Minglani <shubham@linux.com>
-Matt Clay <matt@mystile.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
+Matt Clay <matt@mystile.com>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -125,9 +125,9 @@ def metadata_to_image_config(metadata):
         'command': ('Cmd', None),
         'working_dir': ('WorkingDir', None),
         'entrypoint': ('Entrypoint', None),
-        'volumes': ('Volumes', lambda _list: {parts[0]:{}
-                                              for parts in [v.split()
-                                                            for v in _list]}),
+        #'volumes': ('Volumes', lambda _list: {parts[0]:{}
+        #                                      for parts in [v.split()
+        #                                                    for v in _list]}),
         'labels': ('Labels', None),
         'onbuild': ('OnBuild', None)
     }
@@ -141,7 +141,7 @@ def metadata_to_image_config(metadata):
         Cmd='',
         WorkingDir='',
         Entrypoint=None,
-        Volumes={},
+        #Volumes={},
         Labels={},
         OnBuild=[]
     )


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
Preseeds named and unnamed volumes on commit for instantiation. Thanks to @vbatts for his help.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
# container.yml
version: "2"
settings:
  conductor_base: centos:7
  project_name: test555
services:
  testsvc:
    from: centos:7
    roles:
    - uncletouchy
    volumes:
    - ${HOME}:/me
    - namedvol:/vol1
    - /vol2
volumes:
  namedvol:
   docker: {}
registries: {}

# roles/uncletouchy/tasks/main.yml
- command: mkdir -p /vol1 /vol2
- command: touch /vol1/foo.txt /vol2/bar.txt

$ docker run -it --rm=true f35024476e5b67357bf73229739aae2db0ecf77154a48a833783c037697a8e80 bash
[root@31ad71768308 /]# ls /vol1
foo.txt
[root@31ad71768308 /]# ls /vol2
bar.txt
[root@31ad71768308 /]# mount
overlay on / type overlay (rw,relatime,lowerdir=/var/lib/docker/overlay2/l/WHVVTREQCYXXVC63ZYG76XQRKZ:/var/lib/docker/overlay2/l/QCJM46P6OKLKG4S4UBW7MW5YYR:/var/lib/docker/overlay2/l/LTQ7QBL5FI6IFFYLCEJQMACH6I,upperdir=/var/lib/docker/overlay2/5023c09b3cc34459d35c46ba6fc7bd41aaa1bf59133d10447989f7a14ac5dad9/diff,workdir=/var/lib/docker/overlay2/5023c09b3cc34459d35c46ba6fc7bd41aaa1bf59133d10447989f7a14ac5dad9/work)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev type tmpfs (rw,nosuid,mode=755)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (ro,nosuid,nodev,noexec,relatime)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,mode=755)
openrc on /sys/fs/cgroup/openrc type cgroup (ro,nosuid,nodev,noexec,relatime,release_agent=/lib/rc/sh/cgroup-release-agent.sh,name=openrc)
cpuset on /sys/fs/cgroup/cpuset type cgroup (ro,nosuid,nodev,noexec,relatime,cpuset)
cpu on /sys/fs/cgroup/cpu type cgroup (ro,nosuid,nodev,noexec,relatime,cpu)
cpuacct on /sys/fs/cgroup/cpuacct type cgroup (ro,nosuid,nodev,noexec,relatime,cpuacct)
blkio on /sys/fs/cgroup/blkio type cgroup (ro,nosuid,nodev,noexec,relatime,blkio)
memory on /sys/fs/cgroup/memory type cgroup (ro,nosuid,nodev,noexec,relatime,memory)
devices on /sys/fs/cgroup/devices type cgroup (ro,nosuid,nodev,noexec,relatime,devices)
freezer on /sys/fs/cgroup/freezer type cgroup (ro,nosuid,nodev,noexec,relatime,freezer)
net_cls on /sys/fs/cgroup/net_cls type cgroup (ro,nosuid,nodev,noexec,relatime,net_cls)
perf_event on /sys/fs/cgroup/perf_event type cgroup (ro,nosuid,nodev,noexec,relatime,perf_event)
net_prio on /sys/fs/cgroup/net_prio type cgroup (ro,nosuid,nodev,noexec,relatime,net_prio)
hugetlb on /sys/fs/cgroup/hugetlb type cgroup (ro,nosuid,nodev,noexec,relatime,hugetlb)
pids on /sys/fs/cgroup/pids type cgroup (ro,nosuid,nodev,noexec,relatime,pids)
cgroup on /sys/fs/cgroup/systemd type cgroup (ro,nosuid,nodev,noexec,relatime,name=systemd)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
/dev/vda1 on /_usr type ext4 (rw,relatime,data=ordered)
/dev/vda1 on /vol1 type ext4 (rw,relatime,data=ordered)
/dev/vda1 on /vol2 type ext4 (rw,relatime,data=ordered)
/dev/vda1 on /etc/resolv.conf type ext4 (rw,relatime,data=ordered)
/dev/vda1 on /etc/hostname type ext4 (rw,relatime,data=ordered)
/dev/vda1 on /etc/hosts type ext4 (rw,relatime,data=ordered)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
proc on /proc/bus type proc (ro,nosuid,nodev,noexec,relatime)
proc on /proc/fs type proc (ro,nosuid,nodev,noexec,relatime)
proc on /proc/irq type proc (ro,nosuid,nodev,noexec,relatime)
proc on /proc/sys type proc (ro,nosuid,nodev,noexec,relatime)
proc on /proc/sysrq-trigger type proc (ro,nosuid,nodev,noexec,relatime)
tmpfs on /proc/kcore type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/timer_list type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,mode=755)
tmpfs on /sys/firmware type tmpfs (ro,relatime)

```
