### PR TITLE
Fix default project name on init.

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -110,8 +110,8 @@ def hostcmd_init(base_path, project=None, force=False, **kwargs):
         template_dir = os.path.join(jinja_template_path(), 'init')
         context = {
             u'ansible_container_version': __version__,
-            u'project_name': kwargs.get('project_name',
-                                        os.path.basename(base_path)),
+            u'project_name': kwargs.get('project_name') or
+                                        os.path.basename(base_path),
             u'default_base': DEFAULT_CONDUCTOR_BASE
         }
         for tmpl_filename in os.listdir(template_dir):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
Before, if a `project_name` was not specified on the command line, the project name in a newly initialized `container.yml` would be `None`. With this fix, it's the directory name from the project path.