### PR TITLE
Pass k8s_auth into conductor as ENV vars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,12 +1,12 @@
 Ansible Container has been contribued to by the following authors:
 This list is automatically generated - please file an issue for corrections)
 
-Chris Houseknecht <chouseknecht@ansible.com>
 Joshua "jag" Ginsberg <jag@ansible.com>
+Chris Houseknecht <chouseknecht@ansible.com>
 Ryan Brown <sb@ryansb.com>
 Shubham Minglani <shubham@linux.com>
-Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Matt Clay <matt@mystile.com>
+Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>

--- a/conductor-requirements.txt
+++ b/conductor-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/ansible/ansible/archive/devel.tar.gz
-https://github.com/openshift/openshift-restclient-python/archive/master.tar.gz#egg=openshift-1.0.0
+https://github.com/openshift/openshift-restclient-python/archive/master.tar.gz#egg=openshift
 PyYAML>=3.12
 docker-compose>=1.7
 requests>=2


### PR DESCRIPTION
Fixes #539 

Removed some leftover code in the `generate_orchestraion_playbook` method of k8s/base_engine.py that was attempting to interact with the `openshift` or `kubernetes` module, and update the authorization settings. Since we're not performing a real-time deployment, there's no point to interacting with the module at all.

During the `run` command it does make sense to pass along `settings.k8s_auth` from `container.yml`. Updated the Ansible Helper within the `openshift` module to look for `K8S_AUTH_` environment variables, and modified the `run_conductor` method to set these variables within the conductor. Now when `ansible-playbook` executes, modules will connect to the API using the expected settings.