### PR TITLE
Adds repository_prefix registry attribute

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -632,25 +632,23 @@ class Engine(BaseEngine):
         return playbook
 
     @conductor_only
-    def push(self, image_id, service_name, repository_data):
+    def push(self, image_id, service_name, tag=None, namespace=None, url=None, username=None, password=None,
+             repository_prefix=None, **kwargs):
         """
         Push an image to a remote registry.
         """
-        tag = repository_data.get('tag')
-        namespace = repository_data.get('namespace')
-        url = repository_data.get('url')
         auth_config = {
-            'username': repository_data.get('username'),
-            'password': repository_data.get('password')
+            'username': username,
+            'password': password
         }
 
         build_stamp = self.get_build_stamp_for_image(image_id)
         tag = tag or build_stamp
 
-        repository = "%s/%s-%s" % (namespace, self.project_name, service_name)
+        repository = "%s/%s-%s" % (namespace, repository_prefix or self.project_name, service_name)
         if url != self.default_registry_url:
             url = REMOVE_HTTP.sub('', url)
-            repository = "%s/%s" % (re.sub('/$', '', url), repository)
+            repository = "%s/%s" % (url.rstrip('/'), repository)
 
         logger.info('Tagging %s' % repository)
         self.client.api.tag(image_id, repository, tag=tag)

--- a/container/engine.py
+++ b/container/engine.py
@@ -158,7 +158,7 @@ class BaseEngine(object):
         raise NotImplementedError()
 
     @conductor_only
-    def push(self, image_id, service_name, repository_data):
+    def push(self, image_id, service_name, **kwargs):
         """
         Push an image to a registry.
         """

--- a/docs/rst/container_yml/reference.rst
+++ b/docs/rst/container_yml/reference.rst
@@ -363,9 +363,9 @@ the container port.
 registries
 ..........
 
-Define registries that can be referenced by the ``push`` and ``deploy`` commands. For each registiry provide a *url* and
-and optional namespace. If no namespace is provided, the username found in your .docker/config.json or specified on the
-command line will be used.
+Define registries that can be used by the ``push`` and ``deploy`` commands. For each registry, provide a *url*, an optional
+*namespace*, and an optional *repository_prefix*. For both *namespace* and *repository_prefix*, if a value is not provided, the project
+name is used.
 
 The following is an example taken from a ``container.yml`` file:
 
@@ -377,8 +377,23 @@ The following is an example taken from a ``container.yml`` file:
         namespace: my-project
       openshift:
         url: https://192.168.30.14.xip.io
+        namespace: my-project
+        repository_prefix: foo
 
-Use the following command to push images to the *google* registry:
+The ``deploy`` command will automatically push images before generating the deployment Ansible playbook. Use the ``--push-to`` option
+to specify the registry to which images will be pushed. For example:
+
+.. code-block:: bash
+
+    # Push images and generate the deployment playbook
+    $ ansible-container deploy --push-to openshift
+
+In the above example, images will be pushed to *https://192.168.3.14.xip.io/my-project*. Each image will result in a repository name
+of *foo-<service-name>*, where *foo* is the *repository_prefix* value for the *openshift* registry. For example, suppose the project
+included a service named *web*. The image for it would be pushed to a repository named *foo-web*
+
+You can also use the ``push`` command to push images directly, and bypass the generation of a deployment playbook. The following will
+push images to the *google* registry:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Closes #550 

##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Allows overriding the repository name prefix. Today we push images to a repository consisting of <project_name>-<service_name>. This change provides a mechanism for overriding the <project_name> portion of the repository name.