### PR TITLE
Fix "ImportError: No module named six"

### DIFF
--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -42,7 +42,9 @@ RUN python /get-pip.py && \
 
 # The COPY here will break cache if the version of conductor changed
 COPY /container-src /_ansible/container
+# Fix: 'pip install six' is a temporary fix for setuptools==36.0.0 bug
 RUN cd /_ansible && \
+    pip install six && \
     pip install -r container/conductor-build/conductor-requirements.txt && \
     PYTHONPATH=. LC_ALL="en_US.UTF-8" python container/conductor-build/setup.py develop -v && \
     ansible-galaxy install -p /etc/ansible/roles -r container/conductor-build/conductor-requirements.yml


### PR DESCRIPTION
The six module is not a dependency of setuptools==36.0.0 that is why
we need to explicitly install it to eliminate `ImportError: No module named six`
messages.

Fixes #569

##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
It is a temporary fix until setuptools is corrected.

