### PR TITLE
Fixes missing object creation tasks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,8 +29,8 @@ Florian Dambrine <Lowess@users.noreply.github.com>
 Will Refvem <wbrefvem@users.noreply.github.com>
 Daniel Heitmann <dictvm@horrendum.de>
 Arnaud Moret <arnaud.moret@gmail.com>
-Ted Timmons <ted@perljam.net>
 marc-sensenich <marc-sensenich@users.noreply.github.com>
+Ted Timmons <ted@perljam.net>
 Bruce Becker <brucellino@gmail.com>
 Evan Zeimet <evan.zeimet@cdw.com>
 John Matthews <jwmatthews@gmail.com>
@@ -47,6 +47,7 @@ Erik Nelson <erik@nsk.io>
 Jeff Geerling <geerlingguy@mac.com>
 Shea Stewart <shea.stewart@arctiq.ca>
 fignew <thomas@vorget.com>
+Gabor Lekeny <gabor.lekeny@gmail.com>
 Aaron Cowdin <aaronthebaron@users.noreply.github.com>
 John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>

--- a/container/core.py
+++ b/container/core.py
@@ -182,10 +182,11 @@ def hostcmd_deploy(base_path, project_name, engine_name, var_file=None,
         params.update(kwargs)
 
     if not local_images:
-        url, namespace = push_images(base_path, config.image_namespace, engine_obj, config,
-                                     save_conductor=False, **params)
+        url, namespace, repository_prefix = push_images(base_path, config.image_namespace, engine_obj, config,
+                                                        save_conductor=False, **params)
         params['url'] = url
         params['namespace'] = namespace
+        params['repository_prefix'] = repository_prefix
 
     engine_obj.await_conductor_command(
         'deploy', dict(config), base_path, params,
@@ -378,7 +379,7 @@ def push_images(base_path, image_namespace, engine_obj, config, **kwargs):
     push_params['namespace'] = namespace
     push_params['repository_prefix'] = repository_prefix
     engine_obj.await_conductor_command('push', dict(config), base_path, push_params, save_container=save_conductor)
-    return url, namespace
+    return url, namespace, repository_prefix
 
 
 @host_only

--- a/container/k8s/base_deploy.py
+++ b/container/k8s/base_deploy.py
@@ -398,6 +398,7 @@ class K8sBaseDeploy(object):
             for name, service_config in self._services.items():
                 # Remove deployment for any services where state is 'absent'
                 if service_config.get(self.CONFIG_KEY, {}).get('state', 'present') == 'absent':
+                    task = CommentedMap()
                     task['name'] = 'Remove deployment'
                     task[module_name] = CommentedMap()
                     task[module_name]['state'] = 'absent'

--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -132,11 +132,13 @@ class K8sBaseEngine(DockerEngine):
                                                         volumes=volumes)
 
     @conductor_only
-    def generate_orchestration_playbook(self, url=None, namespace=None, settings=None, **kwargs):
+    def generate_orchestration_playbook(self, url=None, namespace=None, settings=None, repository_prefix=None,
+                                        **kwargs):
         """
         Generate an Ansible playbook to orchestrate services.
         :param url: registry URL where images will be pulled from
         :param namespace: registry namespace
+        :param repository_prefix: prefix to use for the image name
         :param settings: settings dict from container.yml
         :return: playbook dict
         """
@@ -144,8 +146,8 @@ class K8sBaseEngine(DockerEngine):
             if service_config.get('roles'):
                 if url and namespace:
                     # Reference previously pushed image
-                    self.services[service_name][u'image'] = '{}/{}/{}'.format(url.rstrip('/'), namespace,
-                                                                              self.image_name_for_service(service_name))
+                    image_name = "{}-{}".format(repository_prefix or self.project_name, service_name)
+                    self.services[service_name][u'image'] = "{}/{}/{}".format(url.rstrip('/'), namespace, image_name)
                 else:
                     # We're using a local image, so check that the image was built
                     image = self.get_latest_image_for_service(service_name)

--- a/container/openshift/deploy.py
+++ b/container/openshift/deploy.py
@@ -132,6 +132,7 @@ class Deploy(K8sBaseDeploy):
         for name, service_config in self._services.items():
             # Remove routes where state is 'absent'
             if service_config.get(self.CONFIG_KEY, {}).get('state', 'present') == 'absent':
+                task = CommentedMap()
                 task['name'] = 'Remove route'
                 task[module_name] = CommentedMap()
                 task[module_name]['state'] = 'absent'

--- a/docs/rst/reference/deploy.rst
+++ b/docs/rst/reference/deploy.rst
@@ -6,7 +6,10 @@ deploy
 The ``deploy`` command pushes images to a remote registry, and generates an Ansible playbook that can be used to deploy the application to a cloud platform.
 
 The cloud platform is determined by the engine used to generate the deployment. Supported engines include: docker, k8s, and openshift. The default is docker.
-Use the ``--engine`` option to choose the engine.
+Use the ``--engine`` option to choose the engine. For example:
+
+.. code-block:: bash
+    $ ansible-container --engine k8s deploy
 
 The ``deploy`` command maps your ``container.yml`` file to a cloud configuration, depending on the engine. See the :doc:`../../container_yml/reference`
 for details on how directives are mapped, and for cloud specific options.
@@ -32,14 +35,21 @@ If using the URL form, include the namespace. For example: ``registry.example.co
 the default namespace for the engine will be used. In the case of docker, the default is the project name. In the case of k8s and openshift, the *k8s_namespace* defined
 in the *settings* section of ``container.yml`` will be used. If that's not defined, the project name will be used.
 
+The process will use registry credentials from your container engine configuration file (e.g., ${HOME}/.docker/config.json), if they exist, to authenticate with the registry.
+Otherwise, you may specify a username and password on the command line using the ``--username`` and ``--password`` options. If the ``--username`` option is provided without
+``--password``, you will be prompted for the password. After a successful login, the engine configuration file will be updated with the new credentials.
+
+
+.. note::
+
+    If you have a credential store service running in your local environment, and you previously logged into the registry using ``docker login``, the authentication data
+    will not exist in the configuration file. Instead, it is stored in the credential store. Ansible Container will not have access to the credential store. To resolve this, remove
+    the registry entry from the configuration file, and use the Ansible Container ``deploy`` or ``push`` commands to perform the authentication.
+
+
 .. option:: --help
 
 Display usage help.
-
-.. option:: --engine
-
-Specify the deployment engine. The selected engine will be used to generate the Ansible playbook for deploying the application to the corresponding platform.
-Valid engines include: docker, k8s, and openshift, with the default engine being docker.
 
 .. option:: --local-images
 

--- a/docs/rst/reference/options/index.rst
+++ b/docs/rst/reference/options/index.rst
@@ -14,7 +14,7 @@ Enable debug-level logging for all actions (inside and outside conductor).
 
 .. option:: --engine ENGINE_NAME
 
-Select your container engine and orchestrator. Defaults to *docker*.
+Select your container engine and orchestrator. Valid options are: docker, k8s, openshift. Defaults to *docker*.
 
 .. option:: --no-selinux
 

--- a/docs/rst/reference/push.rst
+++ b/docs/rst/reference/push.rst
@@ -3,49 +3,65 @@ push
 
 .. program:: ansible-container push
 
-The ``ansible-container push`` command sends the latest build of your images
-to a container registry of your choosing. This command is analogous to ``docker push``.
+The ``ansible-container push`` command sends the latest build of your images to a container registry of your choosing. This command is analogous to ``docker push``.
 
-If you already have credentials stored in your container engine configuration for
-the URL you provide, Ansible Container uses that credential during "push". Otherwise,
-you may specify a username and email on the command line. Likewise, if you specify a
-password, it is used as part of your credentials; otherwise, the user is prompted to type in the password.
+Use the ``--push-to`` option to specify the registry where images will be pushed. Pass either a registry name defined in the *registries* section
+of ``container.yml``, or pass a URL.
 
-Ansible Container performs a login for you. The credentials are stored in
-your container engine's configuration for future use.
+If using the URL form, include the namespace. For example: ``registry.example.com:5000/myproject``. If a namespace is not provided,
+the default namespace for the engine will be used. In the case of docker, the default is the project name. In the case of k8s and openshift, the *k8s_namespace* defined
+in the *settings* section of ``container.yml`` will be used. If that's not defined, the project name will be used.
 
-.. option:: --username <username>
+The process will use registry credentials from your container engine configuration file (e.g., ${HOME}/.docker/config.json), if they exist, to authenticate with the registry.
+Otherwise, you may specify a username and password on the command line using the ``--username`` and ``--password`` options. If the ``--username`` option is provided without
+``--password``, you will be prompted for the password. After a successful login, the engine configuration file will be updated with the new credentials.
 
-The username to use when logging into the registry.
+.. note::
 
-.. option:: --email <email>
+    If you have a credential store service running in your local environment, and you previously logged into the registry using ``docker login``, the authentication data
+    will not exist in the configuration file. Instead, it is stored in the credential store. Ansible Container will not have access to the credential store. To resolve this, remove
+    the registry entry from the configuration file, and use the Ansible Container ``deploy`` or ``push`` commands to perform the authentication.
 
-The email address associated with your username in the registry.
 
-.. option:: --password <password>
+.. option:: --push-to
 
-The password used to authenticate your user with the registry.
+Pass either a name defined in the *registries* key within container.yml, or the URL to the registry.
 
-.. option:: --push-to <registry name>
+If passing a URL, you can include the namespace. For example: ``registry.example.com:5000/myproject``. If the namespace is not included, the default namespace
+for the engine will be used. For the docker engine, the default namespace is the project name. For k8s and openshift, the *k8s_namespace*
+value will be used from the *settings* section of ``container.yml``. If the value is not set, then the project name will be used.
 
-Pass either a name defined in the *registries* key within container.yml or the actual URL the cluster will use to
-push images. If passing a URL, an example would be 'https://registry.example.com:5000/myproject'.
+When passing a registry name defined in the *registries* section of ``container.yml``, set the *namespace* as an attribute of the registry.
+
+If no ``--push-to`` option is passed, and the ``--local-images`` option is not passed, then the default registry will be used. The current default is
+set to ``https://index.docker.io/v1/``.
+
+.. option:: --username
+
+If the registry requires authentication, pass the username.
+
+.. option:: --password
+
+If the registry requires authentication, pass a password. If the ``--username`` is provided without the ``--password`` option, you will
+be prompted for a password.
+
+.. option:: --email
+
+If registry authentication requires an email address, use to pass the email address.
+
+.. option:: --tag
+
+Tag the images prior to pushing.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
-Define one or more environment variables in the Ansible Builder Container. Format each variable as a
-key=value string.
+Define one or more environment variables in the Ansible Builder Container. Format each variable as a key=value string.
 
 .. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
 
-Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
-volume format.
-
-If ``--with-volumes`` was used during the `build` process to access roles or includes, then pass the same option to the `push` command so that ``main.yml`` can be parsed. 
+Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.
 
 .. option:: --roles-path LOCAL_PATH
 
 If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-
-If ``--roles-path`` was used during the `build` process, then pass the same option to the `push` command so that ``main.yml`` can be parsed. 
 


### PR DESCRIPTION
Closes #565 

##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- Adds missing `create` tasks to the deployment playbook
- Adds `repository_prefix` registry attribute to k8s/openshift playbook generation
- Updates `deploy` and `push` docs