### PR TITLE
get volumes defined, mounted at container build time

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -694,7 +694,7 @@ def conductorcmd_build(engine_name, project_name, services, cache=True,
                         pass
 
                     # Use the conductor's Python runtime
-                    run_kwargs['volumes'] = {engine.get_runtime_volume_id('/usr'): {'bind': '/_usr', 'mode': 'ro'}}
+                    run_kwargs['volumes'][engine.get_runtime_volume_id('/usr')] = {'bind': '/_usr', 'mode': 'ro'}
                     try:
                         run_kwargs['volumes'][engine.get_runtime_volume_id('/lib')] = {'bind': '/_lib', 'mode': 'ro'}
                         extra_library_paths += ":/_lib"


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### SUMMARY

Volumes defined in container.yaml should be available also during container build phase. I belive this was intended by the authors, since in 668-678 of container/core.py there is loop over those volumes and it works if someone decides to use container's local python.
