### PR TITLE
Fix compilation error when running under Python 3.5

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -23,7 +23,7 @@ import tarfile
 try:
     import httplib as StatusCodes
 except ImportError:
-    from http import HTTPStatus as StatusCodes
+    import http.client as StatusCodes
 
 import container
 from container import host_only, conductor_only


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
This compilation error was the only obstacle I encountered when running ansible-container with Python 3.5, despite having no issues at all with Docker and Ansible standalone.
I tested the full build/run/deploy cycle and everything seems to work fine with this fix applied.