### PR TITLE
Add support for secrets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Chris Houseknecht <chouseknecht@ansible.com>
 Ryan Brown <sb@ryansb.com>
 Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
+Eric D. Helms <ericdhelms@gmail.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>

--- a/container/cli.py
+++ b/container/cli.py
@@ -363,6 +363,7 @@ def conductor_commandline():
         conductor_config.services,
         volume_data=conductor_config.volumes,
         repository_data=conductor_config.registries,
+        secrets=conductor_config.secrets,
         **params)
 
 

--- a/container/config.py
+++ b/container/config.py
@@ -214,7 +214,8 @@ class BaseAnsibleContainerConfig(Mapping):
         'volumes',
         'services',
         'defaults',
-        'registries'
+        'registries',
+        'secrets'
     ]
 
     OPTIONS_KUBE_WHITELIST = []
@@ -291,7 +292,7 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def _process_top_level_sections(self):
         self._config['settings'] = self._config.get('settings', yaml.compat.ordereddict())
-        for section in ['volumes', 'registries']:
+        for section in ['volumes', 'registries', 'secrets']:
             logger.debug('Processing section...', section=section)
             setattr(self, section, dict(self._process_section(self._config.get(section, yaml.compat.ordereddict()))))
 
@@ -339,10 +340,11 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def __len__(self):
         # volumes, registries, services, and defaults
-        return 4
+        return 5
 
     def __iter__(self):
         yield self.defaults
         yield self.registries
         yield self.volumes
         yield self.services
+        yield self.secrets

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -107,7 +107,7 @@ class Engine(BaseEngine):
         'domainname', 'hostname', 'ipc', 'mac_address', 'mem_limit',
         'memswap_limit', 'mem_swappiness', 'mem_reservation', 'oom_score_adj',
         'privileged', 'read_only', 'restart', 'shm_size', 'stdin_open', 'tty',
-        'user', 'working_dir',
+        'user', 'working_dir', 'secrets',
     )
     display_name = u'Docker\u2122 daemon'
 

--- a/container/engine.py
+++ b/container/engine.py
@@ -40,6 +40,7 @@ class BaseEngine(object):
         self.devel = devel
         self.selinux = selinux
         self.volumes = kwargs.pop('volume_data', None)
+        self.secrets = kwargs.pop('secrets', None)
 
     @property
     def display_name(self):

--- a/container/k8s/base_deploy.py
+++ b/container/k8s/base_deploy.py
@@ -313,7 +313,10 @@ class K8sBaseDeploy(object):
                 elif key == 'volumes':
                     vols, vol_mounts = self.get_k8s_volumes(value)
                     if vol_mounts:
-                        container['volumeMounts'] = vol_mounts
+                        if 'volumeMounts' not in container:
+                            container['volumeMounts'] = []
+
+                        container['volumeMounts'].extend(vol_mounts)
                     if vols:
                         volumes += vols
                 elif key == 'secrets':

--- a/container/k8s/base_deploy.py
+++ b/container/k8s/base_deploy.py
@@ -27,7 +27,7 @@ class K8sBaseDeploy(object):
     DEFAULT_API_VERSION = 'v1'
     CONFIG_KEY = 'k8s'
 
-    def __init__(self, services=None, project_name=None, volumes=None, auth=None, namespace_name=None, 
+    def __init__(self, services=None, project_name=None, volumes=None, secrets=None, auth=None, namespace_name=None,
                  namespace_description=None, namespace_display_name=None):
         self._services = services
         self._project_name = project_name
@@ -35,6 +35,7 @@ class K8sBaseDeploy(object):
         self._namespace_description = namespace_description
         self._namespace_display_name = namespace_display_name
         self._volumes = volumes
+        self._secrets = secrets
         self._auth = auth
 
     @property
@@ -315,6 +316,15 @@ class K8sBaseDeploy(object):
                         container['volumeMounts'] = vol_mounts
                     if vols:
                         volumes += vols
+                elif key == 'secrets':
+                    vols, vol_mounts = self.get_k8s_secrets(value, service[self.CONFIG_KEY]['secrets'])
+                    if vol_mounts:
+                        if 'volumeMounts' not in container:
+                            container['volumeMounts'] = []
+
+                        container['volumeMounts'].extend(vol_mounts)
+                    if vols:
+                        volumes += vols
                 elif key == 'working_dir':
                     container['workingDir'] = value
                 else:
@@ -491,6 +501,80 @@ class K8sBaseDeploy(object):
                         tasks.append(task)
         return tasks
 
+    def get_secret_templates(self):
+        def _secret(secret_name, secret):
+            template = CommentedMap()
+            template['force'] = secret.get('force', False)
+            template['apiVersion'] = 'v1'
+            template = CommentedMap()
+            template['apiVersion'] = self.DEFAULT_API_VERSION
+            template['kind'] = "Secret"
+            template['metadata'] = CommentedMap([
+                ('name', secret_name),
+                ('namespace', self._namespace_name)
+            ])
+            template['type'] = 'Generic'
+            if secret.get('type'):
+                template['type'] = 'Generic'
+            if secret.get('data'):
+                data = secret['data']
+                template['data'] = {}
+
+                for key, value in data.items():
+                    if type(value) is CommentedMap:
+                        if value['type'] == 'file':
+                            with open(value['value']) as file:
+                                value = file.read()
+                        else:
+                            value = value['value']
+
+                    template['data'][key] = value.encode('base64')
+
+            return template
+
+        templates = CommentedSeq()
+        if self._secrets:
+            for secret_name, secret_config in self._secrets.items():
+                if self.CONFIG_KEY in secret_config:
+                    if secret_config[self.CONFIG_KEY].get('state', 'present') == 'present':
+                        secret = _secret(secret_name, secret_config[self.CONFIG_KEY])
+                        templates.append(secret)
+        return templates
+
+    def get_secret_tasks(self, tags=[]):
+        module_name='k8s_v1_secret'
+        tasks = CommentedSeq()
+        for template in self.get_secret_templates():
+            task = CommentedMap()
+            task['name'] = 'Create Secret'
+            task[module_name] = CommentedMap()
+            task[module_name]['state'] = 'present'
+            if self._auth:
+                for key in self._auth:
+                    task[module_name][key] = self._auth[key]
+            task[module_name]['force'] = template.pop('force', False)
+            task[module_name]['resource_definition'] = template
+            if tags:
+                task['tags'] = copy.copy(tags)
+            tasks.append(task)
+        if self._secrets:
+            for secret_name, secret_config in self._secrets.items():
+                if self.CONFIG_KEY in secret_config:
+                    if secret_config[self.CONFIG_KEY].get('state', 'present') == 'absent':
+                        task = CommentedMap()
+                        task['name'] = 'Remove Secret'
+                        task[module_name] = CommentedMap()
+                        task[module_name]['name'] = secret_name
+                        task[module_name]['namespace'] = self._namespace_name
+                        task[module_name]['state'] = 'absent'
+                        if self._auth:
+                            for key in self._auth:
+                                task[module_name][key] = self._auth[key]
+                        if tags:
+                            task['tags'] = copy.copy(tags)
+                        tasks.append(task)
+        return tasks
+
     @staticmethod
     def get_service_ports(service):
         ports = []
@@ -621,6 +705,54 @@ class K8sBaseDeploy(object):
                 mountPath=destination,
                 name=name,
                 readOnly=(True if permissions == 'ro' else False)
+            ))
+
+        return volumes, volume_mounts
+
+    @classmethod
+    def get_k8s_secrets(cls, docker_secrets, overrides):
+        """ Given an array of Docker secrets return a set of secrets and a set of volumeMounts """
+        secrets = []
+        volume_mounts = []
+        volumes = []
+        docker_default = '/run/secrets'
+        for secret in docker_secrets:
+            source = None
+            target = None
+            mode = None
+            mount_path = docker_default
+            read_only = True
+
+            if type(secret) is dict:
+                source = secret.source
+                target = secret.target
+                mode = secret.mode
+            else:
+                source = secret
+
+            if target:
+                mount_path += '/' + target
+            else:
+                mount_path += '/' + source
+
+            override = filter(lambda x: x['name'] == source, overrides)
+
+            if len(override) == 1:
+                override = override[0]
+                if 'mount_path' in override:
+                    mount_path = override['mount_path']
+                if 'read_only' in override:
+                    read_only = override['read_only']
+
+            volume_mounts.append(dict(
+                mountPath=mount_path,
+                name=source,
+                readOnly=read_only
+            ))
+
+            volumes.append(dict(
+                name=source,
+                secret=dict(secretName=source)
             ))
 
         return volumes, volume_mounts

--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -192,6 +192,7 @@ class K8sBaseEngine(DockerEngine):
         play['tasks'].extend(self.deploy.get_deployment_tasks(engine_state='stop', tags=['stop', 'restart']))
         play['tasks'].extend(self.deploy.get_deployment_tasks(tags=['start', 'restart']))
         play['tasks'].extend(self.deploy.get_pvc_tasks(tags=['start']))
+        play['tasks'].extend(self.deploy.get_secret_tasks(tags=['start']))
 
         playbook = CommentedSeq()
         playbook.append(play)

--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -188,11 +188,11 @@ class K8sBaseEngine(DockerEngine):
                                                'Valid tags include: start, stop, restart, destroy', indent=4)
         play['tasks'].append(self.deploy.get_namespace_task(state='present', tags=['start']))
         play['tasks'].append(self.deploy.get_namespace_task(state='absent', tags=['destroy']))
+        play['tasks'].extend(self.deploy.get_secret_tasks(tags=['start']))
         play['tasks'].extend(self.deploy.get_service_tasks(tags=['start']))
         play['tasks'].extend(self.deploy.get_deployment_tasks(engine_state='stop', tags=['stop', 'restart']))
         play['tasks'].extend(self.deploy.get_deployment_tasks(tags=['start', 'restart']))
         play['tasks'].extend(self.deploy.get_pvc_tasks(tags=['start']))
-        play['tasks'].extend(self.deploy.get_secret_tasks(tags=['start']))
 
         playbook = CommentedSeq()
         playbook.append(play)

--- a/container/k8s/engine.py
+++ b/container/k8s/engine.py
@@ -25,7 +25,7 @@ class Engine(K8sBaseEngine):
     def deploy(self):
         if not self._deploy:
             self._deploy = Deploy(self.services, self.project_name, namespace_name=self.namespace_name,
-                                  volumes=self.volumes)
+                                  volumes=self.volumes, secrets=self.secrets)
         return self._deploy
 
     @property

--- a/container/openshift/engine.py
+++ b/container/openshift/engine.py
@@ -28,6 +28,7 @@ class Engine(K8sBaseEngine):
         if not self._deploy:
             self._deploy = Deploy(self.services, self.project_name,
                                   volumes=self.volumes,
+                                  secrets=self.secrets,
                                   namespace_name=self.namespace_name,
                                   namespace_description=self.namespace_description,
                                   namespace_display_name=self.namespace_display_name)

--- a/docs/rst/container_yml/reference.rst
+++ b/docs/rst/container_yml/reference.rst
@@ -6,13 +6,13 @@ file, defining the services that make up the application, the relationships betw
 from the outside world.
 
 The goal for ``container.yml`` is to provide a single definition of the application that defines how to build images,
-how to run in development, and how to deploy to a production cloud environment. It's one source of configuration that 
+how to run in development, and how to deploy to a production cloud environment. It's one source of configuration that
 works throughout the application lifecycle.
 
 The structure and contents of the file are based on Docker Compose, supporting versions 1 and 2. Looking at a ``container.yml``
-file you will recognize it as mostly Compose with a few notable exceptions. There are directives that are not supported, 
+file you will recognize it as mostly Compose with a few notable exceptions. There are directives that are not supported,
 because they do not translate to the supported clouds, and there are new directives added to support
-multi-environment, and multi-cloud configurations. 
+multi-environment, and multi-cloud configurations.
 
 The aim of this document is to provide a complete reference to ``container.yml``.
 
@@ -42,6 +42,9 @@ networks                   Create named, persistent networks
 version                    Specifiy the version of Compose, '1' or '2'              |checkmark|
 :ref:`top-volumes`         Create named, persistent volumes. The syntax differs     |checkmark|
                            from the Docker specification.
+:ref:`secrets`             Create named secrets. The syntax differs                 |checkmark|
+                           from the Docker specification. View :ref:`secrets`
+                           for details.
 ========================== ======================================================== ============
 
 .. _settings:
@@ -49,26 +52,26 @@ version                    Specifiy the version of Compose, '1' or '2'          
 Settings
 --------
 
-The ``settings`` section is an optional dictionary, or mapping, of project level configuration settings. The following 
-settings are supported: 
+The ``settings`` section is an optional dictionary, or mapping, of project level configuration settings. The following
+settings are supported:
 
 ====================== =====================================================================
-Directive              Definition                                              
+Directive              Definition
 ====================== =====================================================================
-project_name           Set the name of the project. Defaults to the basename of the project 
-                       directory. For built services, project_name is concatenated with service 
+project_name           Set the name of the project. Defaults to the basename of the project
+                       directory. For built services, project_name is concatenated with service
                        name to form the built image name.
 
 conductor_base         The Conductor container does the heavy lifting, and provides a portable
                        Python runtime for building your target containers. It should be derived
                        from the same distribution as you're building your target containers with.
 
-deployment_output_path The deployment_output_path is mounted to the Conductor container, and the 
+deployment_output_path The deployment_output_path is mounted to the Conductor container, and the
                        ``run`` and ``deployment`` commands then write generated Ansible playbooks to it.
                        Defaults to ``./ansible-deployment``.
 :ref:`k8s_auth`        When deploying to K8s or OpenShift, provide API authentication details.
 
-:ref:`k8s_namespace`   When deploying to a K8s or OpenShift cluster, set the namespace, or project name, 
+:ref:`k8s_namespace`   When deploying to a K8s or OpenShift cluster, set the namespace, or project name,
                        in which to deploy the application
 ====================== =====================================================================
 
@@ -92,7 +95,7 @@ The following is a simple example of a ``settings`` section found in a ``contain
       k8s_auth:
         config_file: /etc/k8s/dev_config
     services:
-    ...    
+    ...
 
 Implementation
 ``````````````
@@ -103,24 +106,24 @@ information for these options:
 .. _k8s_auth:
 
 k8s_auth
-........	
+........
 
-The ``k8s_auth`` directive takes a dictionary, or mapping, of options that provide details for 
-authenticating with the K8s or OpenShift API during the ``run`` command. The following options 
+The ``k8s_auth`` directive takes a dictionary, or mapping, of options that provide details for
+authenticating with the K8s or OpenShift API during the ``run`` command. The following options
 are supported:
 
 ====================== =====================================================================
-Directive              Definition                                              
+Directive              Definition
 ====================== =====================================================================
-config_file            Path to a K8s config file. Defaults to ${HOME}/.kube/config. If 
-                       no other options are supplied, the config file will be used to 
+config_file            Path to a K8s config file. Defaults to ${HOME}/.kube/config. If
+                       no other options are supplied, the config file will be used to
                        authenticate with the cluster API.
 
-context                Name of a context found in the config file. 
+context                Name of a context found in the config file.
 
 host                   URL for accessing the API.
 
-api_key                A valid API authentication token.                       
+api_key                A valid API authentication token.
 
 ssl_ca_cert            Path to a CA certificate file.
 
@@ -138,19 +141,19 @@ k8s_namespace
 
 Used to set the namespace, or project name, in which the application will be deployed on the cluster.
 Specifically, values set here will be passed to the ``k8s_namespace``, or ``openshift_project`` module,
-within the Ansible playbook generated by the ``run`` and ``deploy`` commands. 
+within the Ansible playbook generated by the ``run`` and ``deploy`` commands.
 
 Expects a dictionary, or mapping, with the following attributes:
 
 ====================== =====================================================================
-Directive              Definition                                              
+Directive              Definition
 ====================== =====================================================================
-name                   The name of the namespace or project. If not provided, defaults to 
-                       the ``project_name``. 
+name                   The name of the namespace or project. If not provided, defaults to
+                       the ``project_name``.
 
 description            A description of the project. Supported only by OpenShift.
 
-display_name           A title, or more formal name, displayed in the OpenShift console. 
+display_name           A title, or more formal name, displayed in the OpenShift console.
                        Supported only by OpenShift.
 ====================== =====================================================================
 
@@ -160,7 +163,7 @@ display_name           A title, or more formal name, displayed in the OpenShift 
 Services
 --------
 
-The ``services`` section is a dictionary, or mapping, of service name to service settings. For example, the following defines 
+The ``services`` section is a dictionary, or mapping, of service name to service settings. For example, the following defines
 two services, ``web`` and ``db``:
 
 .. code-block:: yaml
@@ -179,9 +182,9 @@ two services, ``web`` and ``db``:
        from: 'openshift/postgresql:latest'
        expose:
          - 5487
- 
+
 The following table details the attributes, or settings, that can be defined for a service. Only those
-with a checkmark in the *Supported* column can be used.  
+with a checkmark in the *Supported* column can be used.
 
 ===================== ======================================================== ============
 Directive             Definition                                               Supported?
@@ -415,6 +418,24 @@ Supported by ``run`` and ``deploy`` commands. The volumes directive mounts host 
 In version 2 of compose a named volume must be defined in the :ref:`top-level volumes directive <top-volumes>`. In version 1, if a named volume does
 not exist, it is automatically created.
 
+In the cloud, host paths result in the creation of an `emptyDir <http://kubernetes.io/docs/user-guide/volumes/#emptydir>`_,
+and a named volume will result in the creation of a persistent volume claim (PVC). The resulting emptyDir or PVC will then
+be mounted to the container using the specified path.
+
+Ansible Container follows the `Portable Configuration pattern <http://kubernetes.io/docs/user-guide/persistent-volumes/#writing-portable-configuration>`_,
+which means:
+
+- It does not create persistent volumes
+- It does create persistent volume claims.
+
+.. _secrets:
+
+secrets
+.......
+
+Supported by the ``deploy`` command. The secrets directive be used to define a literal, file or from a directory to be mounted into
+a container. If supplied secrets are not base64 encoded then they are encoded when the deployment playbook is generated.
+
 .. _volumes_from:
 
 volumes_from
@@ -504,6 +525,7 @@ state                    Set to *present*, if the service should be deployed to 
 :ref:`service_sub`       Adds a mapping of Service object attributes.
 :ref:`deployment_sub`    Adds a mapping of Deployment (or DeploymentConfig for OpenShift) object attributes.
 :ref:`route_sub`         Adds a mapping of OpenShift Route object attributes.
+:ref:`secrets_sub`       Adds a mapping of OpenShift Secrets object attributes to volume mounts in the deployment.
 ======================== ======================================================================================================
 
 .. _service_sub:
@@ -693,6 +715,80 @@ With the new options, the route for port 4443 will be updated with the following
           [...]
           -----END CERTIFICATE-----
 
+.. _secrets_sub:
+
+secrets
+.......
+
+Secrets are mounted into OpenShift deployments as volume mounts inside the containers. Docker secrets have defaults and options that do not directly correlate inside OpenShift. How secrets are defined as volume mounts for a deployment can be defined in this section allowing to set the ``mountPath`` and alter the ``readOnly`` state that is set to ``yes`` by default.
+Route objects are used by OpenShift to expose services externally, and Ansible Container generates routes based on the ``ports`` directive of a service.
+
+Consider the following service defined in ``container.yml``:
+
+.. code-block:: yaml
+
+    services:
+      web:
+        from: centos:7
+        entrypoint: ['/usr/bin/entrypoint.sh']
+        working_dir: /
+        user: apache
+        command: [/usr/bin/dumb-init, httpd, -DFOREGROUND]
+        ports:
+        - 8000:8080
+        - 4443:8443
+        secrets:
+          - apache-certs
+
+For each secret in the set of defined ``secrets``, a volumeMount object is generated, and the above will generate the following mounts:
+
+.. code-block:: yaml
+
+   ...
+   template
+     spec:
+       containers:
+         - name: web
+           volumeMounts:
+             - name: apache-certs
+               mountPath: /run/secrets/apache-certs
+               readOnly: true
+
+The ``mountPath`` is by default set to the standard Docker location of ``/run/secrets``. To customize where the secret is mounted inside OpenShift the value can be overriden:
+
+.. code-block:: yaml
+
+    services:
+      web:
+        from: centos:7
+        entrypoint: ['/usr/bin/entrypoint.sh']
+        working_dir: /
+        user: apache
+        command: [/usr/bin/dumb-init, httpd, -DFOREGROUND]
+        ports:
+        - 8000:8080
+        - 4443:8443
+        secrets:
+          - apache-certs
+        openshift:
+          state: present
+          secrets:
+            - name: apache-certs
+              mount_path: /etc/httpd/pki/apache-certs
+
+This will result in:
+
+.. code-block:: yaml
+
+   ...
+   template
+     spec:
+       containers:
+         - name: web
+           volumeMounts:
+             - name: apache-certs
+               mountPath: /etc/httpd/pki/apache-certs
+               readOnly: true
 
 .. _top-volumes:
 
@@ -772,5 +868,69 @@ match_expressions        A list of expressions used to filter matching volumes.
 requested_storage        The amount of storage being requested. Defaults to 1Gi.
                          See `compute resources <http://kubernetes.io/docs/user-guide/compute-resources/>`_ for abbreviations.
 ======================== ========================================================================================================================
+
+
+.. secrets:
+
+Secrets
+```````
+
+For Docker, the service level ``secrets`` directive works as expected. The top-level ``secrets`` directive, however, has been modified slightly. The following example ``container.yml`` shows the three forms of the service level ``secrets`` directive, and the new top-level ``secrets`` format:
+
+.. code-block:: yaml
+
+    version: '2'
+    services:
+      web:
+        from: centos:7
+        entrypoint: [/usr/bin/entrypoint.sh]
+        working_dir: /
+        user: apache
+        command: [/usr/bin/dumb-init, httpd, -DFOREGROUND]
+        ports:
+        - 8000:8080
+        - 4443:8443
+        roles:
+        - apache-container
+        secrets:
+          - apache-certs
+
+    secrets:
+      my-secrets:
+        docker: {}
+        openshift:
+          state: present
+          force: false
+          type: Generic
+          data:
+            username: admin
+            password:
+              type: literal
+              value: mypassword
+      apache-certs:
+        openshift:
+          state: present
+          force: false
+          type: Generic
+          data:
+            apache-cert:
+              type: file
+              value: "{{ APACHE_CERT_PATH }}"
+            apache-key:
+              type: file
+              value: "certs/private/apache.key"
+
+For additional information about Docker secrets see Docker's `secrets configuration reference <https://docs.docker.com/compose/compose-file/#volume-configuration-reference>`_.
+
+
+For ``openshift`` and ``k8s``, the following options are available:
+
+======================== =============================================================================================================
+Directive                Definition
+======================== =============================================================================================================
+type                     Specify secret type, the most common is generic.
+data                     The actual secrets which can specified as either a type of file or literal. A file type can point to a single
+                         file or directory of files. The name for each data entry is assumed to be the key label on the object.
+======================== =============================================================================================================
 
 

--- a/docs/rst/container_yml/reference.rst
+++ b/docs/rst/container_yml/reference.rst
@@ -42,9 +42,9 @@ networks                   Create named, persistent networks
 version                    Specifiy the version of Compose, '1' or '2'              |checkmark|
 :ref:`top-volumes`         Create named, persistent volumes. The syntax differs     |checkmark|
                            from the Docker specification.
-:ref:`secrets`             Create named secrets. The syntax differs                 |checkmark|
-                           from the Docker specification. View :ref:`secrets`
-                           for details.
+:ref:`secrets_top`         Create named secrets that can be mounted to pods as      |checkmark|
+                           volumes during cloud deployment. The syntax differs
+                           from the Docker specification.
 ========================== ======================================================== ============
 
 .. _settings:
@@ -236,6 +236,7 @@ pid                   Sets the PID mode to the host PID mode, enabling between
 privileged            Run in privileged mode                                   |checkmark|
 read_only             Mount the container's file system as read only           |checkmark|
 restart               Restart policy to apply when a container exits           |checkmark|
+secrets               Mount secrets as volumes                                 |checkmark|
 security_opt          Override default labeling scheme
 shm_size              Size of /dev/shm
 stdin_open            Keep stdin open                                          |checkmark|
@@ -433,8 +434,8 @@ which means:
 secrets
 .......
 
-Supported by the ``deploy`` command. The secrets directive be used to define a literal, file or from a directory to be mounted into
-a container. If supplied secrets are not base64 encoded then they are encoded when the deployment playbook is generated.
+Supported by the ``deploy`` and ``run`` commands. The secrets directive can be used to associate a secret with a container, mounting it as
+a volume. Use the top-level :ref:`secrets directive <secrets_top>` to define a secret. To set cloud specific options, view :ref:`k8s_openshift_options`.
 
 .. _volumes_from:
 
@@ -458,7 +459,9 @@ When using the ``k8s`` and ``openshift`` engines, the following commands are ava
  - stop
  - destroy
 
-To impact how objects are created, a ``k8s`` or ``openshift`` section can be added to a specific service, and to a named volume within the top-level volumes directive. The following presents an``openshift`` example:
+To impact how objects are created, a ``k8s`` or ``openshift`` section can be added to a specific service, to a named volume within
+the top-level :ref:`volumes directive <volumes_top>`, or to a secret within the top-level :ref:`secrets directive <secrets_top>`.
+The following presents an ``openshift`` example:
 
 
 .. code-block:: yaml
@@ -517,16 +520,15 @@ Service level directives
 
 The following directives can be added to a ``k8s`` or ``openshift`` section within a service:
 
-======================== ======================================================================================================
+======================== =========================================================================================================================
 Directive                Definition
-======================== ======================================================================================================
-state                    Set to *present*, if the service should be deployed to the cluster, or *absent*, if it should not.
-                         Defaults to *present*.
+======================== =========================================================================================================================
+state                    Set to *present*, if the service should be deployed to the cluster, or *absent*, if it should not. Defaults to *present*.
 :ref:`service_sub`       Adds a mapping of Service object attributes.
 :ref:`deployment_sub`    Adds a mapping of Deployment (or DeploymentConfig for OpenShift) object attributes.
 :ref:`route_sub`         Adds a mapping of OpenShift Route object attributes.
 :ref:`secrets_sub`       Adds a mapping of OpenShift Secrets object attributes to volume mounts in the deployment.
-======================== ======================================================================================================
+======================== =========================================================================================================================
 
 .. _service_sub:
 
@@ -720,10 +722,7 @@ With the new options, the route for port 4443 will be updated with the following
 secrets
 .......
 
-Secrets are mounted into OpenShift deployments as volume mounts inside the containers. Docker secrets have defaults and options that do not directly correlate inside OpenShift. How secrets are defined as volume mounts for a deployment can be defined in this section allowing to set the ``mountPath`` and alter the ``readOnly`` state that is set to ``yes`` by default.
-Route objects are used by OpenShift to expose services externally, and Ansible Container generates routes based on the ``ports`` directive of a service.
-
-Consider the following service defined in ``container.yml``:
+Secrets are included in K8s and OpenShift deployments as volume mounts to a container. Consider the following service defined in ``container.yml``:
 
 .. code-block:: yaml
 
@@ -738,9 +737,9 @@ Consider the following service defined in ``container.yml``:
         - 8000:8080
         - 4443:8443
         secrets:
-          - apache-certs
+        - apache-certs
 
-For each secret in the set of defined ``secrets``, a volumeMount object is generated, and the above will generate the following mounts:
+For each secret, a ``volumeMount`` object is generated. The above will generate the following during ``deploy`` and ``run``:
 
 .. code-block:: yaml
 
@@ -754,7 +753,8 @@ For each secret in the set of defined ``secrets``, a volumeMount object is gener
                mountPath: /run/secrets/apache-certs
                readOnly: true
 
-The ``mountPath`` is by default set to the standard Docker location of ``/run/secrets``. To customize where the secret is mounted inside OpenShift the value can be overriden:
+The ``mountPath`` is by default set to the standard Docker location of ``/run/secrets``, and ``readOnly`` defaults to ``true``. Within the  ``k8s`` or
+``openshift`` section for the service, set the ``mount_path`` and ``read_only`` attributes of a secret as follows:
 
 .. code-block:: yaml
 
@@ -769,12 +769,13 @@ The ``mountPath`` is by default set to the standard Docker location of ``/run/se
         - 8000:8080
         - 4443:8443
         secrets:
-          - apache-certs
+        - apache-certs
         openshift:
           state: present
           secrets:
             - name: apache-certs
               mount_path: /etc/httpd/pki/apache-certs
+              read_only: false
 
 This will result in:
 
@@ -788,7 +789,7 @@ This will result in:
            volumeMounts:
              - name: apache-certs
                mountPath: /etc/httpd/pki/apache-certs
-               readOnly: true
+               readOnly: false
 
 .. _top-volumes:
 
@@ -869,13 +870,13 @@ requested_storage        The amount of storage being requested. Defaults to 1Gi.
                          See `compute resources <http://kubernetes.io/docs/user-guide/compute-resources/>`_ for abbreviations.
 ======================== ========================================================================================================================
 
-
-.. secrets:
+.. _secrets_top:
 
 Secrets
 ```````
 
-For Docker, the service level ``secrets`` directive works as expected. The top-level ``secrets`` directive, however, has been modified slightly. The following example ``container.yml`` shows the three forms of the service level ``secrets`` directive, and the new top-level ``secrets`` format:
+For Docker, the service level ``secrets`` directive works as expected. The top-level ``secrets`` directive, however, has been modified slightly. The following example
+``container.yml`` shows the service level ``secrets`` directive, and the new top-level ``secrets`` format:
 
 .. code-block:: yaml
 
@@ -893,7 +894,7 @@ For Docker, the service level ``secrets`` directive works as expected. The top-l
         roles:
         - apache-container
         secrets:
-          - apache-certs
+        - apache-certs
 
     secrets:
       my-secrets:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
I'd like to support being able to define and supply secrets to services using the secrets support in Kubernetes and Openshift. Secrets are stand-alone similar to volumes and can be mounted inside a container with a volume and volumeMount declaration. Docker and Kubernetes have different ways of defining secrets and the first pass at this includes a focus on Kubernetes and Openshift.

I've run and tested this in my own environment with success and am opening up the PR for feedback and discussion. I've attempted to make the configuration as flexible as possible as well as making it easy on users. For example, we could require that users have to supply the secrets data base64 encoded to the container.yml file. This I felt requires the user to figure out a lot on their own and work around some of the challenges with loading a file in properly. By just specifying the path to a local file the users config is simplified.

I hope this will be considered for an upcoming release as this is the next big step needed to fully deploy my application and all of it;s pieces in a near production ready setup.