### PR TITLE
Adds pull_from_url to registry

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,10 +10,10 @@ Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
+Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Dylan Silva <thaumos@users.noreply.github.com>
 Fabian von Feilitzsch <fabianvf@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
-Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
 Will Refvem <wbrefvem@gmail.com>
 Sebastien Plisson <sebastien.plisson@gmail.com>
@@ -32,6 +32,7 @@ Arnaud Moret <arnaud.moret@gmail.com>
 marc-sensenich <marc-sensenich@users.noreply.github.com>
 Ted Timmons <ted@perljam.net>
 Bruce Becker <brucellino@gmail.com>
+Tomas Tomecek <ttomecek@redhat.com>
 Evan Zeimet <evan.zeimet@cdw.com>
 John Matthews <jwmatthews@gmail.com>
 Sean Summers <ssummer3@nd.edu>
@@ -45,10 +46,10 @@ Chrrrles Paul <chrrrles@users.noreply.github.com>
 Andrea De Pirro <andrea.depirro@yameveo.com>
 Erik Nelson <erik@nsk.io>
 Jeff Geerling <geerlingguy@mac.com>
-Shea Stewart <shea.stewart@arctiq.ca>
 fignew <thomas@vorget.com>
 Gabor Lekeny <gabor.lekeny@gmail.com>
 Aaron Cowdin <aaronthebaron@users.noreply.github.com>
 John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>
 grimmjow <ryanbrown.dev@gmail.com>
+Shea Stewart <shea.stewart@arctiq.ca>


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
We push images into `minishift` using `https://local.openshift` as the registry URL. This is because the default IP address of `172.30.1.1` is not available outside of the VM, and so we create a `route` object, and associate it to an `/etc/hosts` entry. 

The flip side is also true, in that the host entry is not accessible inside the VM. Within the VM, the cluster expects to pull images via the `172.30.1.1` address. To accommodate this, I added a `pull_from_url` attribute to the registry properties. A registry definition within `container.yml` may now looking like the following:

```
...
registries:
  openshift:
    url: https://local.opeshift
    namespace: demo
    registry_prefix: foo
    pull_from_url: https://172.30.1.1:5000
```

This PR also adds the tag value to the `image` directive within the generated deployment. And, it provides some doc updates and fixes.