### PR TITLE
Fix the stop command

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -73,6 +73,11 @@ class HostCommand(object):
                                         u'Conductor. Format each variable as a key=value string.',
                                    default=[])
 
+        if cmd in ('run', 'stop', 'restart', 'destroy'):
+            subparser.add_argument('--production', action='store_true',
+                               help=u'Run with the production configuration.',
+                               default=False, dest='production')
+
         if cmd in ('build', 'run', 'deploy', 'push'):
             subparser.add_argument('--roles-path', action='store', default=None,
                                    help=u'Specify a local path containing roles you want to '
@@ -172,9 +177,6 @@ class HostCommand(object):
         subparser.add_argument('service', action='store',
                                help=u'The specific services you want to run',
                                nargs='*')
-        subparser.add_argument('--production', action='store_true',
-                               help=u'Run the production configuration locally',
-                               default=False, dest='production')
         subparser.add_argument('-d', '--detached', action='store_true',
                                help=u'Run the application in detached mode', dest='detached')
         self.subcmd_common_parsers(parser, subparser, 'run')

--- a/container/cli.py
+++ b/container/cli.py
@@ -78,11 +78,6 @@ class HostCommand(object):
                                help=u'Run with the production configuration.',
                                default=False, dest='production')
 
-        if cmd in ('build', 'run', 'deploy', 'push'):
-            subparser.add_argument('--roles-path', action='store', default=None,
-                                   help=u'Specify a local path containing roles you want to '
-                                        u'use in the Conductor.')
-
         if cmd in ('deploy', 'push'):
             subparser.add_argument('--username', action='store',
                                help=u'If authentication with the registry is required, provide a valid username.',
@@ -126,6 +121,9 @@ class HostCommand(object):
                                     u'previously built image for your hosts. Disable '
                                     u'that with this flag.',
                                dest='purge_last', default=True)
+        subparser.add_argument('--roles-path', action='store', default=None,
+                               help=u'Specify a local path containing roles you want to '
+                                    u'use during the build process.')
         subparser.add_argument('--save-conductor-container', action='store_true',
                                help=u'Leave the Ansible Builder Container intact upon build completion. '
                                     u'Use for debugging and testing.', default=False)

--- a/container/core.py
+++ b/container/core.py
@@ -229,6 +229,8 @@ def hostcmd_destroy(base_path, project_name, engine_name, var_file=None, cache=T
     assert_initialized(base_path)
     logger.debug('Got extra args to `destroy` command', arguments=kwargs)
     config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    if not kwargs['production']:
+        config.set_env('dev')
 
     engine_obj = load_engine(['RUN'],
                              engine_name, config.project_name,
@@ -253,6 +255,9 @@ def hostcmd_destroy(base_path, project_name, engine_name, var_file=None, cache=T
 def hostcmd_stop(base_path, project_name, engine_name, force=False, services=[],
                  **kwargs):
     config = get_config(base_path, engine_name=engine_name, project_name=project_name)
+    if not kwargs['production']:
+        config.set_env('dev')
+
     engine_obj = load_engine(['RUN'],
                              engine_name, config.project_name,
                              config['services'], **kwargs)
@@ -275,6 +280,9 @@ def hostcmd_stop(base_path, project_name, engine_name, force=False, services=[],
 def hostcmd_restart(base_path, project_name, engine_name, force=False, services=[],
                     **kwargs):
     config = get_config(base_path, engine_name=engine_name, project_name=project_name)
+    if not kwargs['production']:
+        config.set_env('dev')
+
     engine_obj = load_engine(['RUN'],
                              engine_name, config.project_name,
                              config['services'], **kwargs)
@@ -775,6 +783,10 @@ def conductorcmd_run(engine_name, project_name, services, **kwargs):
     playbook = engine.generate_orchestration_playbook(**kwargs)
     logger.debug("in conductorcmd_run", playbook=playbook)
     rc = run_playbook(playbook, engine, services, tags=['start'], **kwargs)
+    if rc:
+        raise AnsibleContainerException(
+            'Error executing the run command. Not all service may be running.'
+        )
     logger.info(u'All services running.', playbook_rc=rc)
 
 

--- a/container/core.py
+++ b/container/core.py
@@ -779,13 +779,11 @@ def conductorcmd_run(engine_name, project_name, services, **kwargs):
         [service for service, service_desc in services.items()
          if service_desc.get('roles')])
 
-    logger.debug("In conductorcmd_run", kwargs=kwargs)
     playbook = engine.generate_orchestration_playbook(**kwargs)
-    logger.debug("in conductorcmd_run", playbook=playbook)
     rc = run_playbook(playbook, engine, services, tags=['start'], **kwargs)
     if rc:
         raise AnsibleContainerException(
-            'Error executing the run command. Not all service may be running.'
+            'Error executing the run command. Not all containers may be running.'
         )
     logger.info(u'All services running.', playbook_rc=rc)
 
@@ -797,6 +795,10 @@ def conductorcmd_restart(engine_name, project_name, services, **kwargs):
                 engine=engine.display_name)
     playbook = engine.generate_orchestration_playbook(**kwargs)
     rc = run_playbook(playbook, engine, services, tags=['restart'], **kwargs)
+    if rc:
+        raise AnsibleContainerException(
+            'Error executing the restart command. Not all containers may be running.'
+        )
     logger.info(u'All services restarted.', playbook_rc=rc)
 
 
@@ -822,6 +824,10 @@ def conductorcmd_destroy(engine_name, project_name, services, **kwargs):
                 engine=engine.display_name)
     playbook = engine.generate_orchestration_playbook(**kwargs)
     rc = run_playbook(playbook, engine, services, tags=['destroy'], **kwargs)
+    if rc:
+        raise AnsibleContainerException(
+            'Error executing the destroy command. Not all containers and images may have been removed.'
+        )
     logger.info(u'All services destroyed.', playbook_rc=rc)
 
 @conductor_only

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -129,9 +129,14 @@ class Engine(BaseEngine):
         return self._client
 
     @property
-    def ansible_args(self):
-        """Additional commandline arguments necessary for ansible-playbook runs."""
-        return u'-c docker'
+    def ansible_build_args(self):
+        """Additional commandline arguments necessary for ansible-playbook runs during build"""
+        return '-c docker'
+
+    @property
+    def ansible_orchestrate_args(self):
+        """Additional commandline arguments necessary for ansible-playbook runs during orchestrate"""
+        return '-c local'
 
     @property
     def default_registry_url(self):

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -358,7 +358,8 @@ class Engine(BaseEngine):
                 raise exceptions.AnsibleContainerConductorException(
                     u'Conductor exited with status %s' % exit_code
                 )
-            elif command in ('run', 'destroy', 'stop', 'restart') and params.get('deployment_output_path'):
+            elif command in ('run', 'destroy', 'stop', 'restart') and params.get('deployment_output_path') \
+                    and not self.debug:
                 # Remove any ansible-playbook residue
                 output_path = params['deployment_output_path']
                 for path in ('files', 'templates'):

--- a/container/engine.py
+++ b/container/engine.py
@@ -46,8 +46,13 @@ class BaseEngine(object):
         return __name__.split('.')[-2].capitalize()
 
     @property
-    def ansible_args(self):
-        """Additional commandline arguments necessary for ansible-playbook runs."""
+    def ansible_build_args(self):
+        """Additional commandline arguments necessary for ansible-playbook runs during build"""
+        raise NotImplementedError()
+
+    @property
+    def ansible_orchestrate_args(self):
+        """Additional commandline arguments necessary for ansible-playbook runs during orchestrate"""
         raise NotImplementedError()
 
     @property

--- a/docs/rst/reference/build.rst
+++ b/docs/rst/reference/build.rst
@@ -3,19 +3,13 @@ build
 
 .. program::ansible-container build
 
-The ``ansible-container build`` command spins up the builder container and runs
-your playbook against the base images described in the ``container.yml`` file. At
-the end of a successful run of this command, in your container engine you will have
-images built for each of the containers in your orchestration. This is analogous to
-``docker build``.
+The ``ansible-container build`` command starts the Conductor container, and runs the Ansible roles for each service in ``container.yml``. For each service, it starts a container using the ``from`` image, and then generates and executes a playbook for each role.
+
+Each playbook runs inside the Conductor, and executes tasks on the service container, using the Docker connection plugin. When finished, a commit is performed on the service container, the container is stopped, and an image is created for the service. At the end of a successful run of this command, a built image will exist for each custom service (i.e., a service defined with one or more Ansible roles). This is analogous to ``docker build``.
 
 .. option:: --flatten
 
-By default, Ansible Container commits the changes your playbook made to the base image,
-but it retains the original layers from that base image. Specifying this option, Ansible
-Container flattens the union filesystem of your image to a single layer. This
-does break caching, so builds won'e be able to reuse cached layers and will
-fully rebuild your services even if you haven't changed anything.
+By default, Ansible Container commits the changes your playbook made to the base image, but it retains the original layers from that base image. Specifying this option, Ansible Container flattens the union filesystem of your image to a single layer. This does break caching, so builds won'e be able to reuse cached layers and will fully rebuild your services even if you haven't changed anything.
 
 .. note::
 
@@ -42,49 +36,39 @@ A shortcut for --no-conductor-cache and --no-container-cache.
 
 .. option:: --no-conductor-cache
 
-The Conductor container uses your container engine's built-it caching mechanisms during
-rebuilds, and Ansible Container will maintain its own per-role cache for your built images.
-To disable these caches and ensure a clean rebuild, use this option.
+The process that builds the Conductor image uses the build engine's built-in caching mechanisms during rebuilds. The default engine is Docker. Use this option to disable the engine's build cache, and force a full build of the conductor image.
 
 .. option:: --no-container-cache
 
-During builds the contents of the roles are used for caching indivual layers.
-To disable these caches and ensure a clean rebuild, use this option.
-
+During the build of each service image, a hash of each Ansible role is associated with the image layer produced when the role is first executed. If the role hash does not change between builds, then the associated image layer is used, and the role is not executed. Use this option to disable this caching mechanism, and force the execution of all roles.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
-Define one or more environment variables in the Ansible Conductor container. Format each variable as a
-key=value string.
+Define one or more environment variables in the Conductor container. Format each variable as a key=value string.
+
+.. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
+
+Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.
+
+.. option:: --roles-path ROLES_PATH
+
+If using roles not found in the ``roles`` directory within the project, use this option to specify the local path containing the roles. The specified path will be mounted to the conductor container, making the roles available to the build process.
 
 .. option:: --use-local-python
 
-Ansible Container will mount the ``/usr`` volume from the conductor container into the target container as ``/_usr``,
-and use the Python runtime from ``/_usr`` to run Ansible modules. Use this option to prevent this behavior, and force
-it to use the Python runtime found locally on the target container.
+Ansible Container will mount the ``/usr`` volume from the conductor container into the target container as ``/_usr`` and use the Python runtime from ``/_usr`` to run Ansible modules. Use this option to prevent this behavior, and force it to use the Python runtime found locally on the target container.
 
 .. option:: ansible_options
 
-You may also provide additional commandline arguments to give Ansible in executing your
-playbook. Use this option with care, as there is no real sanitation or validation of
-your input. It is recommended you only use this option to limit the hosts you build
-against (for example, if you only want to rebuild one container), to add extra variables,
-or to specify tags.
+You may also provide additional commandline arguments to give Ansible in executing your playbook. Use this option with care, as there is no real sanitation or validation of your input. It is recommended you only use this option to limit the hosts you build against (for example, if you only want to rebuild one container), to add extra variables, or to specify tags.
 
-Note that for proper parsing, you will likely have to use ``--`` to separate the
-ansible-container options from the ansible-playbook options.
+Note that for proper parsing, you will likely have to use ``--`` to separate the ansible-container options from the ansible-playbook options.
 
 Caveats
 ```````
 
-Ansible ordinarily connects to hosts it is managing via the SSH protocol. Ansible Container
-uses the latest Docker connection plugin to communicate from the Ansible Builder Container to
-the other containers. Since not all modules presently function with the Docker connection plugin, 
-it limits the modules your playbook may rely on. As examples:
+Ansible ordinarily connects to hosts it is managing via the SSH protocol. Ansible Container uses the latest Docker connection plugin to communicate from the Conductor container to the other containers. Since not all modules presently function with the Docker connection plugin, it limits the modules your playbook may rely on. As examples:
 
-* The `become` methods do not work with Ansible Container, as `su` is disallowed in the Docker
-  connection plugin (see `#16226 <https://github.com/ansible/ansible/pull/16226>`_)
-  and `sudo` requires a TTY. Instead, use the `remote_user` parameter.
+* The `become` methods do not work with Ansible Container, as `su` is disallowed in the Docker connection plugin (see `#16226 <https://github.com/ansible/ansible/pull/16226>`_), and `sudo` requires a TTY. Instead, use the `remote_user` parameter.
 
-Also, remember that the ``ansible-playbook`` executable runs on your Conductor container, not
-your local host, and thus operates in the filesystem and network context of the build container.
+Also, remember that the ``ansible-playbook`` executable runs on your Conductor container, not your local host, and thus operates in the filesystem and network context of the build container.

--- a/docs/rst/reference/deploy.rst
+++ b/docs/rst/reference/deploy.rst
@@ -76,10 +76,6 @@ Define one or more environment variables in the Ansible Builder Container. Forma
 
 Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.
 
-.. option:: --roles-path LOCAL_PATH
-
-If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-
 .. option:: --username
 
 If the registry requires authentication, pass the username.

--- a/docs/rst/reference/destroy.rst
+++ b/docs/rst/reference/destroy.rst
@@ -5,4 +5,9 @@ destroy
 
 .. program:: ansible-container destroy
 
-Stop then delete all containers for the services in *container.yml*, then destroy any built images for services. This will delete all service images, running containers, and the conductor image.
+Stop then delete all containers for the services in *container.yml*, then destroy any built images for services. This will delete all service images, running
+containers, and the conductor image.
+
+.. option:: --production
+
+By default, any `dev_overrides` specified in ``container.yml`` will be used and included in the orchestration playbook. Use this flag to ignore `dev_overrides`, and run containers using the production configuration. If containers were started using the `--production` option, then it's a good idea to use this option with the `destroy` command.

--- a/docs/rst/reference/push.rst
+++ b/docs/rst/reference/push.rst
@@ -60,8 +60,3 @@ Define one or more environment variables in the Ansible Builder Container. Forma
 .. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
 
 Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.
-
-.. option:: --roles-path LOCAL_PATH
-
-If you have Ansible roles in a local path other than your `ansible/` directory that you wish to use, specify that path with this option.
-

--- a/docs/rst/reference/restart.rst
+++ b/docs/rst/reference/restart.rst
@@ -3,7 +3,11 @@ restart
 
 .. program:: ansible-container restart [service [service ...]]
 
-Restart containers for the services defined in *container.yml.* Optionally list one or more services to restart. The name of the service must match a service defined in
-container.yml. If no services are specified, all services found in *container.yml* will be restarted.
+Restart containers. Optionally list one or more services to restart. The name of the service must match a service defined in ``container.yml``. If no services are specified, all services will be restarted.
+
+.. option:: --production
+
+By default, any `dev_overrides` specified in ``container.yml`` will be used and included in the orchestration playbook. Use this flag to ignore `dev_overrides`, and run containers using the production configuration. If containers were started using the `--production` option, then it's a good idea to use this option with the ``restart`` command.
+
 
 

--- a/docs/rst/reference/run.rst
+++ b/docs/rst/reference/run.rst
@@ -9,25 +9,16 @@ deploys, this is roughly analogous to ``docker-compose run``.
 
 .. option:: --production
 
-By default, any `dev_overrides` you specified in your ``container.yml`` will be
-applied when running your containers. You may specify to run your containers with
-the production configuration by using this flag.
+By default, any `dev_overrides` specified in ``container.yml`` will be used and included in the orchestration playbook. Use this flag to ignore `dev_overrides`, and run containers using the production configuration.
 
 .. option:: --remove-orphans
 
-Remove containers for services not defined in container.yml.
+Remove containers for services not defined in ``container.yml``.
 
 .. option:: --with-variables WITH_VARIABLES [WITH_VARIABLES ...]
 
-Define one or more environment variables in the Ansible Builder Container. Format each variable as a
-key=value string.
+Define one or more environment variables in the Conductor container. Format each variable as a key=value string.
 
 .. option:: --with-volumes WITH_VOLUMES [WITH_VOLUMES ...]
 
-Mount one or more volumes to the Ansible Builder Container. Specify volumes as strings using the Docker
-volume format.
-
-.. option:: --roles-path LOCAL_PATH
-
-If you have Ansible roles in a local path other than your ``roles/`` directory that you wish to use
-during your build/run/deploy, specify that path with this option.
+Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.

--- a/docs/rst/reference/stop.rst
+++ b/docs/rst/reference/stop.rst
@@ -3,11 +3,15 @@ stop
 
 .. program:: ansible-container stop [service [service ...]]
 
-Stop running containers for the services defined in *container.yml*.
+Stop running containers.
 
 Optionally, list one or more services to stop. The name of the service must match a service defined in
-*container.yml*.
+``container.yml``.
 
 .. option:: -f, --force
 
 Stop running containers by using the kill command.
+
+.. option:: --production
+
+By default, any `dev_overrides` specified in ``container.yml`` will be used and included in the orchestration playbook. Use this flag to ignore `dev_overrides`, and run containers using the production configuration. If containers were started using the `--production` option, then it's a good idea to use this option with the ``stop`` command.


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
- `stop`, `run`, `restart`, and `destroy` should all run with the same `container.yml` configuration. In other words, if running locally, then all should use the `dev_overrides` options.
- Adds the `--production` option to `stop`, `run`, and `destroy`
- Split `ansible_args` for the engine into `ansible_build_args` and `ansible_orchestrate_args`. Prior to this all playbook runs happened with `-c docker`. However, when running against `localhost`, the options should be `-c local`. Thought this might fix the sporadically missing `--debug` output from playbook runs, but unfortunately it didn't. Still seems like a good idea though. 
- The docker_service module was updated. This PR will be the first to run with the latest changes.