### PR TITLE
Fix for tgz getting downloaded as a directory

### DIFF
--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -32,13 +32,12 @@ RUN apt-get update -y && \
 RUN apk add --no-cache -U python2-dev make git rsync libffi libffi-dev openssl openssl-dev gcc musl-dev tar openssh
 {% endif %}
 
-ADD https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz /tmp/docker.tgz
+ADD https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz /tmp
 
 COPY /contrib/get-pip.py /get-pip.py
 RUN python /get-pip.py && \
     mkdir -p /etc/ansible/roles /_ansible/src && \
-    cd /usr/local/bin && \
-    tar -xz --strip-components=1 -f /tmp/docker.tgz
+    cp -R /tmp/docker/* /usr/local/bin/
 
 # The COPY here will break cache if the version of conductor changed
 COPY /container-src /_ansible/container


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### SUMMARY
This should fix #592. It seems docker.tgz file is coming out as a folder. At least this is the behavior with my Docker for Mac
