### PR TITLE
Support secrets via Ansible vault

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Chris Houseknecht <chouseknecht@ansible.com>
 Ryan Brown <sb@ryansb.com>
 Shubham Minglani <shubham@linux.com>
 Matt Clay <matt@mystile.com>
+Eric D. Helms <ericdhelms@gmail.com>
 Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>

--- a/container/cli.py
+++ b/container/cli.py
@@ -169,6 +169,9 @@ class HostCommand(object):
         subparser.add_argument('--local-images', action='store_true',
                                help=u'Prevents images from being pushed to the default registry',
                                default=False, dest='local_images')
+        subparser.add_argument('--vault-file', action='store',
+                               help=u'A vault file to use to populate secrets',
+                               nargs='+', default=[], dest='vault_files')
         self.subcmd_common_parsers(parser, subparser, 'deploy')
 
     def subcmd_run_parser(self, parser, subparser):
@@ -177,6 +180,15 @@ class HostCommand(object):
                                nargs='*')
         subparser.add_argument('-d', '--detached', action='store_true',
                                help=u'Run the application in detached mode', dest='detached')
+        subparser.add_argument('--vault-file', action='store',
+                               help=u'A vault file to use to populate secrets',
+                               nargs='+', default=[], dest='vault_files')
+        subparser.add_argument('--vault-password-file', action='store',
+                               help=u'An optional file containing the vault password',
+                               dest='vault_password_file')
+        subparser.add_argument('--ask-vault-pass', action='store_true',
+                               help=u'Asks for the fault file password at run time',
+                               dest='ask_vault_pass')
         self.subcmd_common_parsers(parser, subparser, 'run')
 
 
@@ -375,6 +387,7 @@ def conductor_commandline():
         conductor_config.services,
         volume_data=conductor_config.volumes,
         repository_data=conductor_config.registries,
+        secrets=conductor_config.secrets,
         **params)
 
 

--- a/container/config.py
+++ b/container/config.py
@@ -53,12 +53,13 @@ class BaseAnsibleContainerConfig(Mapping):
     engine_list = ['docker', 'openshift', 'k8s']
 
     @container.host_only
-    def __init__(self, base_path, var_file=None, engine_name=None, project_name=None):
+    def __init__(self, base_path, var_file=None, engine_name=None, project_name=None, vault_files=None):
         self.base_path = base_path
         self.var_file = var_file
         self.engine_name = engine_name
         self.config_path = path.join(self.base_path, 'container.yml')
         self.cli_project_name = project_name
+        self.cli_vault_files = vault_files
         self.remove_engines = set(self.engine_list) - set([engine_name])
         self.set_env('prod')
 
@@ -85,6 +86,22 @@ class BaseAnsibleContainerConfig(Mapping):
         if self._config.get('settings', {}).get('conductor', {}).get('base'):
             return self._config['settings']['conductor']['base']
         return DEFAULT_CONDUCTOR_BASE
+
+    @property
+    def vault_files(self):
+        if self.cli_vault_files:
+            # Give precedence to CLI args
+            return self.cli_vault_files
+        if self._config.get('settings', {}).get('vault_files'):
+            return self._config['settings']['vault_files']
+
+    @property
+    def vault_password_file(self):
+        if self.cli_vault_password_file:
+            # Give precedence to CLI args
+            return self.cli_vault_password_file
+        if self._config.get('settings', {}).get('vault_password_file'):
+            return self._config['settings']['vault_password_file']
 
     @property
     @abstractproperty
@@ -214,7 +231,8 @@ class BaseAnsibleContainerConfig(Mapping):
         'volumes',
         'services',
         'defaults',
-        'registries'
+        'registries',
+        'secrets'
     ]
 
     OPTIONS_KUBE_WHITELIST = []
@@ -291,7 +309,7 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def _process_top_level_sections(self):
         self._config['settings'] = self._config.get('settings', yaml.compat.ordereddict())
-        for section in ['volumes', 'registries']:
+        for section in ['volumes', 'registries', 'secrets']:
             logger.debug('Processing section...', section=section)
             setattr(self, section, dict(self._process_section(self._config.get(section, yaml.compat.ordereddict()))))
 
@@ -339,10 +357,11 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def __len__(self):
         # volumes, registries, services, and defaults
-        return 4
+        return 5
 
     def __iter__(self):
         yield self.defaults
         yield self.registries
         yield self.volumes
         yield self.services
+        yield self.secrets

--- a/container/core.py
+++ b/container/core.py
@@ -191,6 +191,8 @@ def hostcmd_deploy(base_path, project_name, engine_name, var_file=None,
                                    save_conductor=False, **params)
         params.update(push_options)
 
+    params['vault_files'] = config.vault_files
+
     engine_obj.await_conductor_command(
         'deploy', dict(config), base_path, params,
         save_container=config.get('settings', {}).get('save_conductor_container', False))

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -107,7 +107,7 @@ class Engine(BaseEngine):
         'domainname', 'hostname', 'ipc', 'mac_address', 'mem_limit',
         'memswap_limit', 'mem_swappiness', 'mem_reservation', 'oom_score_adj',
         'privileged', 'read_only', 'restart', 'shm_size', 'stdin_open', 'tty',
-        'user', 'working_dir',
+        'user', 'working_dir', 'secrets',
     )
     display_name = u'Docker\u2122 daemon'
 

--- a/container/engine.py
+++ b/container/engine.py
@@ -40,6 +40,7 @@ class BaseEngine(object):
         self.devel = devel
         self.selinux = selinux
         self.volumes = kwargs.pop('volume_data', None)
+        self.secrets = kwargs.pop('secrets', None)
 
     @property
     def display_name(self):

--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -133,7 +133,7 @@ class K8sBaseEngine(DockerEngine):
 
     @conductor_only
     def generate_orchestration_playbook(self, url=None, namespace=None, settings=None, repository_prefix=None,
-                                        pull_from_url=None, tag=None, **kwargs):
+                                        pull_from_url=None, tag=None, vault_files=None, **kwargs):
         """
         Generate an Ansible playbook to orchestrate services.
         :param url: registry URL where images were pushed.
@@ -177,10 +177,12 @@ class K8sBaseEngine(DockerEngine):
         play['gather_facts'] = 'no'
         play['connection'] = 'local'
         play['roles'] = CommentedSeq()
+        play['vars_files'] = CommentedSeq()
         play['tasks'] = CommentedSeq()
         role = CommentedMap([
             ('role', 'ansible.kubernetes-modules')
         ])
+        play['vars_files'].extend(vault_files)
         play['roles'].append(role)
         play.yaml_set_comment_before_after_key(
             'roles', before='Include Ansible Kubernetes and OpenShift modules', indent=4)
@@ -188,6 +190,7 @@ class K8sBaseEngine(DockerEngine):
                                                'Valid tags include: start, stop, restart, destroy', indent=4)
         play['tasks'].append(self.deploy.get_namespace_task(state='present', tags=['start']))
         play['tasks'].append(self.deploy.get_namespace_task(state='absent', tags=['destroy']))
+        play['tasks'].extend(self.deploy.get_secret_tasks(tags=['start']))
         play['tasks'].extend(self.deploy.get_service_tasks(tags=['start']))
         play['tasks'].extend(self.deploy.get_deployment_tasks(engine_state='stop', tags=['stop', 'restart']))
         play['tasks'].extend(self.deploy.get_deployment_tasks(tags=['start', 'restart']))

--- a/container/k8s/engine.py
+++ b/container/k8s/engine.py
@@ -25,7 +25,7 @@ class Engine(K8sBaseEngine):
     def deploy(self):
         if not self._deploy:
             self._deploy = Deploy(self.services, self.project_name, namespace_name=self.namespace_name,
-                                  volumes=self.volumes)
+                                  volumes=self.volumes, secrets=self.secrets)
         return self._deploy
 
     @property

--- a/container/openshift/engine.py
+++ b/container/openshift/engine.py
@@ -28,6 +28,7 @@ class Engine(K8sBaseEngine):
         if not self._deploy:
             self._deploy = Deploy(self.services, self.project_name,
                                   volumes=self.volumes,
+                                  secrets=self.secrets,
                                   namespace_name=self.namespace_name,
                                   namespace_description=self.namespace_description,
                                   namespace_display_name=self.namespace_display_name)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
This is a variation of my other secrets PR supporting and requiring that all secrets come from a vault (or vars) file during the deploy stage. This still does not attempt to handle the docker based run phase for secrets. In this incarnation, secrets are defined by a name, and then referenced throughout the container.yml file. No secret data is stored in container.yml. Further, no secrets are read in and stored in the generated deployment playbook either. 

Secrets defined in the top level secrets section are converted into an expected variable file and variables expected to be defined in the variable/vault. The name of the secret is turned into an expected variable file and the data items are expected to be keys within that variable file. For example:

```
secrets:
  certs:
    openshift:
      data:
        - httpd-cert
        - httpd-key
```

The deployment playbook would generate a `vars_files` entry that expects a file `certs.yml` to exist containing the keys `httpd_cert` and `httpd_key`. This allows a deployment playbook to be paired any secrets file decoupling the two.

There are a couple design considerations with this method to consider:

  1) Kubernetes secret names accept more characters than Ansible variable names
     -- k8s accepts `.`, `-` while Ansible does not
  2) Currently this auto substitutes any characters Ansible does not support into underscores. This means the vault or variable file supplied must also take into account this difference in naming. For example, `httpd.crt` turns into `httpd_crt`.
  3) Should we be doing auto-substitution? Should we enforce Ansible variable syntax restrictions? This limits what a user can define within their kubernetes environment if we do.

I do plan to write up the docs around this, but I wanted to put out the current implementation and considerations I had to make since I was testing and using it locally.