### PR TITLE
Documentation update to reference container_base in container.yml (#532)

### DIFF
--- a/docs/rst/container_yml/reference.rst
+++ b/docs/rst/container_yml/reference.rst
@@ -81,8 +81,7 @@ The following is a simple example of a ``settings`` section found in a ``contain
 
     version: '2'
     settings:
-      conductor:
-        base: 'ubuntu:xenial'
+      conductor_base: 'ubuntu:xenial'
       project_name: myproject
 
       k8s_namespace:


### PR DESCRIPTION
Using the example from [this page](http://docs.ansible.com/ansible-container/container_yml/reference.html) the conductor base image was not being set properly.  Looking through the code I found `container_base` which I've documented here instead.