### PR TITLE
Fix yaml code block rendering

### DIFF
--- a/docs/rst/roles/access.rst
+++ b/docs/rst/roles/access.rst
@@ -20,6 +20,7 @@ In ``container.yml``, refer to roles by name. For example, if the role ``apache`
 locally, then the following will execute the role during ``build``: 
 
 .. code-block:: yaml
+
 version: '2'
 services:
   web:


### PR DESCRIPTION
Insert a missing newline to enable proper rendering of the yaml codeblock.

##### ISSUE TYPE
 - Docs Pull Request

##### SUMMARY
A yaml code block is not rendering correctly

Insert a newline in order to fix the rendering.


```

```
