### PR TITLE
Pull missing images during build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Pierre-Louis Bonicoli <pierre-louis@libregerbil.fr>
 Greg DeKoenigsberg <greg.dekoenigsberg@gmail.com>
 Sandra Wills <swills@ansible.com>
 Dusty Mabe <dusty@dustymabe.com>
+Eric D Helms <eric.d.helms@gmail.com>
 Josiah Goodson <josiah.goodson@gmail.com>
 Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Dylan Silva <thaumos@users.noreply.github.com>
@@ -42,7 +43,6 @@ John Matthews <jwmatthews@gmail.com>
 Sean Summers <ssummer3@nd.edu>
 Alex Yanchenko <alex@yanchenko.com>
 Balazs Zagyvai <github.zagyi@spamgourmet.com>
-Eric D Helms <eric.d.helms@gmail.com>
 Trishna Guha <trishnaguha17@gmail.com>
 Ali Asad Lotia <ali.asad.lotia@gmail.com>
 szinck1 <szinck@gmail.com>
@@ -56,3 +56,4 @@ John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>
 grimmjow <ryanbrown.dev@gmail.com>
 Shea Stewart <shea.stewart@arctiq.ca>
+Michael Carden <mike.carden@gmail.com>

--- a/container/core.py
+++ b/container/core.py
@@ -641,6 +641,12 @@ def conductorcmd_build(engine_name, project_name, services, cache=True, local_py
             continue
         logger.info(u'Building service...', service=service_name, project=project_name)
         cur_image_id = engine.get_image_id_by_tag(service['from'])
+        if not cur_image_id:
+            cur_image_id = engine.pull_image_by_tag(service['from'])
+            if not cur_image_id:
+                raise AnsibleContainerException(
+                    "Failed to find image {}. Try `docker image pull {}`".format(service['from'])
+                )
         # the fingerprint hash tracks cacheability
         fingerprint_hash = hashlib.sha256('%s::' % cur_image_id)
         logger.debug(u'Base fingerprint hash = %s', fingerprint_hash.hexdigest(),

--- a/container/engine.py
+++ b/container/engine.py
@@ -133,6 +133,10 @@ class BaseEngine(object):
     def get_image_id_by_tag(self, tag):
         raise NotImplementedError()
 
+    @conductor_only
+    def pull_image_by_tag(self, image_name):
+        raise NotImplementedError
+
     def get_latest_image_id_for_service(self, service_name):
         raise NotImplementedError()
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Fixes #400 

During the build process, attempt to pull missing images. Images will be pulled from the engine's default registry. If using the default engine, Docker, then images will be pulled from Docker Hub. If this is not desired, then at this point, it's incumbent on the user to pull the images manually prior to running the build process. 

It may be possible, although not tested, for a registry to be included in the `from` directive, and if credentials exist in the default registry auth file (e.g. ~/.docker/config.json), for the images to be pulled from a private registry. This PR does mount the default auth file to the conductor, making it available to the `pull` process.