### PR TITLE
Adds var_file to settings in container.yml

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -250,9 +250,10 @@ class HostCommand(object):
         parser.add_argument('--project-name', '-n', action='store', dest='project_name',
                             help=u'Specify an alternate name for your project. Defaults '
                                  u'to the directory it lives in.', default=None)
-        parser.add_argument('--var-file', action='store',
-                            help=u'Path to a YAML or JSON formatted file providing variables for '
-                                 u'Jinja2 templating in container.yml.', default=None)
+        parser.add_argument('--vars-files', '--var-file', '--vars-file', action='append',
+                            help=u'One or or more YAML or JSON formatted files providing variables for '
+                                 u'Jinja2 style variable substitution in container.yml.',
+                            default=[], dest='vars_files')
         parser.add_argument('--no-selinux', action='store_false', dest='selinux',
                             help=u"Disables the 'Z' option from being set on volumes automatically "
                                  u"mounted to the build container.", default=True)

--- a/container/config.py
+++ b/container/config.py
@@ -55,7 +55,7 @@ class BaseAnsibleContainerConfig(Mapping):
     @container.host_only
     def __init__(self, base_path, var_file=None, engine_name=None, project_name=None):
         self.base_path = base_path
-        self.var_file = var_file
+        self.cli_var_file = var_file
         self.engine_name = engine_name
         self.config_path = path.join(self.base_path, 'container.yml')
         self.cli_project_name = project_name
@@ -155,8 +155,11 @@ class BaseAnsibleContainerConfig(Mapping):
             tmp_defaults.update(copy.deepcopy(config['defaults']), relax=True)
             config['defaults'] = tmp_defaults
         defaults = config.setdefault('defaults', yaml.compat.ordereddict())
-        if self.var_file:
-            defaults.update(self._get_variables_from_file(), relax=True)
+
+        var_file = self.cli_var_file or config.get('settings', {}).get('var_file')
+        if var_file:
+            defaults.update(self._get_variables_from_file(var_file=var_file), relax=True)
+
         logger.debug('The default type is', defaults=str(type(defaults)), config=str(type(config)))
         if PY2 and type(defaults) == yaml.compat.ordereddict:
             defaults.update(self._get_environment_variables(), relax=True)
@@ -181,14 +184,14 @@ class BaseAnsibleContainerConfig(Mapping):
         logger.debug(u'Read environment variables', env_vars=env_vars)
         return env_vars
 
-    def _get_variables_from_file(self):
+    def _get_variables_from_file(self, var_file):
         """
         Looks for file relative to base_path. If not found, checks relative to base_path/ansible.
         If file extension is .yml | .yaml, parses as YAML, otherwise parses as JSON.
 
         :return: ruamel.yaml.compat.ordereddict
         """
-        abspath = path.abspath(self.var_file)
+        abspath = path.abspath(var_file)
         if not path.exists(abspath):
             dirname, filename = path.split(abspath)
             raise AnsibleContainerConfigException(

--- a/container/config.py
+++ b/container/config.py
@@ -53,9 +53,9 @@ class BaseAnsibleContainerConfig(Mapping):
     engine_list = ['docker', 'openshift', 'k8s']
 
     @container.host_only
-    def __init__(self, base_path, var_file=None, engine_name=None, project_name=None):
+    def __init__(self, base_path, vars_files=None, engine_name=None, project_name=None):
         self.base_path = base_path
-        self.cli_var_file = var_file
+        self.cli_vars_files = vars_files
         self.engine_name = engine_name
         self.config_path = path.join(self.base_path, 'container.yml')
         self.cli_project_name = project_name
@@ -156,9 +156,10 @@ class BaseAnsibleContainerConfig(Mapping):
             config['defaults'] = tmp_defaults
         defaults = config.setdefault('defaults', yaml.compat.ordereddict())
 
-        var_file = self.cli_var_file or config.get('settings', {}).get('var_file')
-        if var_file:
-            defaults.update(self._get_variables_from_file(var_file=var_file), relax=True)
+        vars_files = self.cli_vars_files or config.get('settings', {}).get('vars_files')
+        if vars_files:
+            for var_file in vars_files:
+                defaults.update(self._get_variables_from_file(var_file=var_file), relax=True)
 
         logger.debug('The default type is', defaults=str(type(defaults)), config=str(type(config)))
         if PY2 and type(defaults) == yaml.compat.ordereddict:
@@ -195,8 +196,8 @@ class BaseAnsibleContainerConfig(Mapping):
         if not path.exists(abspath):
             dirname, filename = path.split(abspath)
             raise AnsibleContainerConfigException(
-                u'Variables file "%s" not found. (I looked in "%s" for it.)' % (
-                    filename, dirname))
+                u'Variables file "%s" not found. (I looked in "%s" for it.)' % (filename, dirname)
+            )
         logger.debug("Use variable file: %s", abspath, file=abspath)
 
         if path.splitext(abspath)[-1].lower().endswith(('yml', 'yaml')):

--- a/container/core.py
+++ b/container/core.py
@@ -124,10 +124,10 @@ def hostcmd_init(base_path, project=None, force=False, **kwargs):
 
 
 @host_only
-def hostcmd_build(base_path, project_name, engine_name, var_file=None,
+def hostcmd_build(base_path, project_name, engine_name, vars_files=None,
                  **kwargs):
     conductor_cache = kwargs['cache'] and kwargs['conductor_cache']
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     engine_obj = load_engine(['BUILD', 'RUN'],
                              engine_name, config.project_name,
                              config['services'], **kwargs)
@@ -166,10 +166,10 @@ def hostcmd_build(base_path, project_name, engine_name, var_file=None,
         'build', dict(config), base_path, kwargs, save_container=save_container)
 
 @host_only
-def hostcmd_deploy(base_path, project_name, engine_name, var_file=None,
+def hostcmd_deploy(base_path, project_name, engine_name, vars_files=None,
                    cache=True, **kwargs):
     assert_initialized(base_path)
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     local_images = kwargs.get('local_images')
     output_path = kwargs.pop('deployment_output_path', None) or config.deployment_path
 
@@ -196,11 +196,11 @@ def hostcmd_deploy(base_path, project_name, engine_name, var_file=None,
         save_container=config.get('settings', {}).get('save_conductor_container', False))
 
 @host_only
-def hostcmd_run(base_path, project_name, engine_name, var_file=None, cache=True,
+def hostcmd_run(base_path, project_name, engine_name, vars_files=None, cache=True,
                 **kwargs):
     assert_initialized(base_path)
     logger.debug('Got extra args to `run` command', arguments=kwargs)
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     if not kwargs['production']:
         config.set_env('dev')
 
@@ -228,10 +228,10 @@ def hostcmd_run(base_path, project_name, engine_name, var_file=None, cache=True,
         save_container=config.get('settings', {}).get('save_conductor_container', False))
 
 @host_only
-def hostcmd_destroy(base_path, project_name, engine_name, var_file=None, cache=True, **kwargs):
+def hostcmd_destroy(base_path, project_name, engine_name, vars_files=None, cache=True, **kwargs):
     assert_initialized(base_path)
     logger.debug('Got extra args to `destroy` command', arguments=kwargs)
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     if not kwargs['production']:
         config.set_env('dev')
 
@@ -255,9 +255,9 @@ def hostcmd_destroy(base_path, project_name, engine_name, var_file=None, cache=T
         save_container=config.get('settings', {}).get('save_conductor_container', False))
 
 @host_only
-def hostcmd_stop(base_path, project_name, engine_name, var_file=None, force=False, services=[],
+def hostcmd_stop(base_path, project_name, engine_name, vars_files=None, force=False, services=[],
                  **kwargs):
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     if not kwargs['production']:
         config.set_env('dev')
 
@@ -280,9 +280,9 @@ def hostcmd_stop(base_path, project_name, engine_name, var_file=None, force=Fals
 
 
 @host_only
-def hostcmd_restart(base_path, project_name, engine_name, var_file=None, force=False, services=[],
+def hostcmd_restart(base_path, project_name, engine_name, vars_files=None, force=False, services=[],
                     **kwargs):
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name,  project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name,  project_name=project_name)
     if not kwargs['production']:
         config.set_env('dev')
 
@@ -304,14 +304,14 @@ def hostcmd_restart(base_path, project_name, engine_name, var_file=None, force=F
 
 
 @host_only
-def hostcmd_push(base_path, project_name, engine_name, var_file=None, **kwargs):
+def hostcmd_push(base_path, project_name, engine_name, vars_files=None, **kwargs):
     """
     Push images to a registry. Requires authenticating with the registry prior to starting
     the push. If your engine's config file does not already contain an authorization for the
     registry, pass username and/or password. If you exclude password, you will be prompted.
     """
     assert_initialized(base_path)
-    config = get_config(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
 
     engine_obj = load_engine(['LOGIN', 'PUSH'],
                              engine_name, config.project_name,

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -42,10 +42,10 @@ conductor_dir = os.path.dirname(container.__file__)
 make_temp_dir = MakeTempDir
 
 
-def get_config(base_path, var_file=None, engine_name=None, project_name=None):
+def get_config(base_path, vars_files=None, engine_name=None, project_name=None):
     mod = importlib.import_module('.%s.config' % engine_name,
                                   package='container')
-    return mod.AnsibleContainerConfig(base_path, var_file=var_file, engine_name=engine_name, project_name=project_name)
+    return mod.AnsibleContainerConfig(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
 
 
 def assert_initialized(base_path):

--- a/docs/rst/container_yml/reference.rst
+++ b/docs/rst/container_yml/reference.rst
@@ -70,6 +70,8 @@ deployment_output_path The deployment_output_path is mounted to the Conductor co
 
 :ref:`k8s_namespace`   When deploying to a K8s or OpenShift cluster, set the namespace, or
                        project name in which to deploy the application
+vars_files             List of variable files to use for Jinja2 template rendering while
+                       parsing ``container.yml``
 ====================== =====================================================================
 
 Example

--- a/docs/rst/reference/options/index.rst
+++ b/docs/rst/reference/options/index.rst
@@ -12,6 +12,12 @@ Show help message and exit.
 
 Enable debug-level logging for all actions (inside and outside conductor).
 
+.. option:: --devel
+
+Enable "developer mode." This is mostly useful for working on the ansible-container codebase to speed up testing changes. If you aren't testing changes to the ansible-container codebase, it's unlikely you need this option.
+
+Instead of building ansible-container Python source into the conductor container, this option mounts the ansible-container from the host machine for every command. Mounting the source every time means you don't have to rebuild the conductor container to update the code, speeding up the dev-test-run cycle immensely.
+
 .. option:: --engine ENGINE_NAME
 
 Select your container engine and orchestrator. Valid options are: docker, k8s, openshift. Defaults to *docker*.
@@ -24,14 +30,7 @@ Stops the 'Z' option from being added to any volumes that get automatically moun
 
 Specify a path to your project. Defaults to the current working directory.
 
-.. option:: --var-file
+.. option:: --vars-files VARS_FILES, --var-file VARS_FILES, --vars-file VARS_FILES
 
-Path to a YAML or JSON formatted file providing variables for Jinja2 template rendering in container.yml. Provide an absolute
-file path, or a path relative to the *project BASE_PATH* or relative to *project BASE_PATH/ansible*. If the file
-extension is one of 'yml' or 'yaml', the file will be parsed as YAML. Otherwise, it is parsed as JSON.
-
-.. option:: --devel
-
-Enable "developer mode." This is mostly useful for working on the ansible-container codebase to speed up testing changes. If you aren't testing changes to the ansible-container codebase, it's unlikely you need this option.
-
-Instead of building ansible-container Python source into the conductor container, this option mounts the ansible-container from the host machine for every command. Mounting the source every time means you don't have to rebuild the conductor container to update the code, speeding up the dev-test-run cycle immensely.
+Specify one or more files containing variable definitions to use when performing Jinja2 template rendering while parsing ``container.yml``. Each file should be a an absolute
+file path, or a path relative to the *project BASE_PATH* or relative to *project BASE_PATH/ansible*. If the file extension is one of 'yml' or 'yaml', it will be parsed as YAML. Otherwise, it will be parsed as JSON.

--- a/test/tests/validate_config.py
+++ b/test/tests/validate_config.py
@@ -58,25 +58,22 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.assertEqual(self.config.project_name, 'baz')
 
     def test_should_parse_yaml_file(self):
-        self.config.var_file = self.var_file
         result = {}
-        for key, value in self.config._get_variables_from_file():
+        for key, value in self.config._get_variables_from_file(self.var_file):
             result[key] = value
         self.assertEqual(result['debug'], 1, 'Failed to parse devel.yml - checked debug')
         self.assertEqual(result['web_image'], "python:2.7", "Failed to parse devel.yml - web_image")
 
     def test_should_parse_json_file(self):
-        self.config.var_file = os.path.join(self.project_path, 'vars.txt')
         result = {}
-        for key, value in self.config._get_variables_from_file():
+        for key, value in self.config._get_variables_from_file(os.path.join(self.project_path, 'vars.txt')):
             result[key] = value
         self.assertEqual(result['debug'], 1, 'Failed to parse devel.txt - checked debug')
         self.assertEqual(result['web_image'], "python:2.7", "Failed to parse devel.txt - web_image")
 
     def test_should_raise_file_not_found_error(self):
-        self.config.var_file = os.path.join(self.project_path, 'foo')
         with self.assertRaises(AnsibleContainerConfigException) as exc:
-             self.config._get_variables_from_file()
+             self.config._get_variables_from_file(os.path.join(self.project_path, 'foo'))
         self.assertIn('not found', exc.exception.args[0])
 
     def test_should_read_environment_vars(self):
@@ -87,7 +84,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
     def test_should_give_precedence_to_env_vars(self):
         # If an environment var exists, it should get precedence.
         os.environ.update({u'AC_FOO': 'cats'})
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -100,7 +97,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         # If no environment var, then var defined in var_file should get precedence.
         if os.environ.get('AC_FOO'):
             del os.environ['AC_FOO']
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -113,7 +110,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         # If no environment var and no var_file, then the default value should be used.
         if os.environ.get('AC_FOO'):
             del os.environ['AC_FOO']
-        self.config.var_file = None
+        self.config.cli_var_file = None
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -124,7 +121,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
 
     def test_should_replace_pwd_in_volumes(self):
         # test that $PWD gets resolved
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -137,7 +134,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
 
     def test_should_also_replace_pwd_in_volumes(self):
         # test that ${PWD} gets resolved
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -149,7 +146,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
                                                        json.dumps(conductor_config.services, indent=4)))
 
     def test_should_resolve_lookup(self):
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('prod')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -159,7 +156,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.assertIn(self.project_path, conductor_config['services']['web']['environment'][0])
 
     def test_should_use_dev_overrides(self):
-        self.config.var_file = self.var_file
+        self.config.cli_var_file = self.var_file
         self.config.set_env('dev')
         container.ENV = 'conductor'
         container.utils.DataLoader = DataLoader
@@ -169,7 +166,7 @@ class TestAnsibleContainerConfig(unittest.TestCase):
         self.assertIn('DEBUG', conductor_config['services']['web']['environment'][0])
 
     # def test_should_resolve_filter(self):
-    #     self.config.var_file = 'devel.yml'
+    #     self.config.cli_var_file = 'devel.yml'
     #     self.config.set_env('dev')
     #     self.assertEqual(self.config._config['services']['web']['environment'][2], 'VERSION={0}'.format(__version__))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
- Adds `--vars-files` CLI option, with `--var-file` and `--vars-file` as aliases, to accept one or more variables files as parameters.
- Adds `vars_files` option to settings
- Adds doc updates for `--vars-files` and `settings.vars_files`