### PR TITLE
Fix pip install commands with extra_requires

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     raise ImportError(
         u'You must install Ansible Container with Docker(tm) support. '
-        u'Try:\npip install ansible-container==%s[docker]' % (
+        u'Try:\npip install ansible-container[docker]==%s' % (
         container.__version__
     ))
 

--- a/container/k8s/engine.py
+++ b/container/k8s/engine.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     raise ImportError(
         u'You must install Ansible Container with Kubernetes support. '
-        u'Try:\npip install ansible-container==%s[k8s]' % (
+        u'Try:\npip install ansible-container[k8s]==%s' % (
         container.__version__
     ))
 

--- a/container/openshift/engine.py
+++ b/container/openshift/engine.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     raise ImportError(
         u'You must install Ansible Container with OpenShift support. '
-        u'Try:\npip install ansible-container==%s[openshift]' % (
+        u'Try:\npip install ansible-container[openshift]==%s' % (
         __version__
     ))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY

The pip syntax for extra_requires is
`pip install foo[bar]==0.0.1`, not `pip install foo==0.0.1[bar]`

```
$ pip install ansible-container==0.9.1[docker]
Collecting ansible-container==0.9.1[docker]
  Could not find a version that satisfies the requirement
ansible-container==0.9.1[docker] (from versions: 0.1.0, 0.2.0, 0.3.0,
0.9.0.0, 0.9.1)
No matching distribution found for ansible-container==0.9.1[docker]
```

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>
