### PR TITLE
Fixes #147 COMPOSE_HTTP_TIMEOUT regression

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -528,7 +528,7 @@ class Engine(BaseEngine):
         try:
             image_id = self.client.images.pull(repo, tag=tag)
         except docker_errors.APIError as exc:
-            raise exceptions.AnsibleContainerException("Failed to pull {}: {}".format(image_name, str(exc)))
+            raise exceptions.AnsibleContainerException("Failed to pull {}: {}".format(image, str(exc)))
         return image_id
 
     @log_runs

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -38,6 +38,7 @@ try:
     from docker.errors import DockerException
     from docker.api.container import ContainerApiMixin
     from docker.models.containers import RUN_HOST_CONFIG_KWARGS
+    from docker.constants import DEFAULT_TIMEOUT_SECONDS
 except ImportError:
     raise ImportError(
         u'You must install Ansible Container with Docker(tm) support. '
@@ -83,6 +84,23 @@ def log_runs(fn):
         return fn(self, *args, **kwargs)
     return __wrapped__
 
+def get_timeout():
+    timeout = DEFAULT_TIMEOUT_SECONDS
+    source = None
+    if os.environ.get('DOCKER_CLIENT_TIMEOUT'):
+        timeout_value = os.environ.get('DOCKER_CLIENT_TIMEOUT')
+        source = 'DOCKER_CLIENT_TIMEOUT'
+    elif os.environ.get('COMPOSE_HTTP_TIMEOUT'):
+        timeout_value = os.environ.get('COMPOSE_HTTP_TIMEOUT')
+        source = 'COMPOSE_HTTP_TIMEOUT'
+    if source:
+        try:
+            timeout = int(timeout_value)
+        except ValueError:
+            raise Exception("Error: {0} set to '{1}'. Expected an integer.".format(source, timeout_value))
+    logger.debug("Setting Docker client timeout to {0}".format(timeout))
+    return timeout
+
 
 class Engine(BaseEngine):
 
@@ -120,7 +138,8 @@ class Engine(BaseEngine):
     def client(self):
         if not self._client:
             try:
-                self._client = docker.from_env(version='auto')
+                timeout = get_timeout()
+                self._client = docker.from_env(version='auto', timeout=timeout)
             except DockerException as exc:
                 if 'Connection refused' in str(exc):
                     raise exceptions.AnsibleContainerDockerConnectionRefused()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It looks like issue #147 was originally resolved by PR #318, but I'm building a 1.8GB image in ansible-container 0.9.1 and getting the same behavior as that user originally reported - but neither exporting COMPOSE_HTTP_TIMEOUT=3000 to my outer "build" environment nor adding it to the conductor settings environment changes the (read timeout=60) in my error output.

If I add the timeout parameter to the Docker client instantiation in `container/docker/engine.py` as in the original pull request I am able to build the image.

The reason for the regression seems to be a switch from directly instantiating `docker.AutoVersionClient` to calling `docker.from_env`. It's not clear to me why `COMPOSE_HTTP_TIMEOUT` is not being used by `docker-py` internally when instantiating a client with `from_env`, but `from_env` does support the timeout parameter, so this pull request refers to os.environ from `container/docker/engine.py` to set the timeout parameter with `COMPOSE_HTTP_TIMEOUT`

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
###### Before:
```
ansible-container build

...django container builds as expected...

PLAY RECAP *********************************************************************
django                     : ok=19   changed=16   unreachable=0    failed=0

Applied role to service role=ordereddict([('role', 'marcusianlevine.django-container'), ('var_files', ['secrets/defaults.yml', 'env_vars/base.yml', 'env_vars
/rabbitmq.yml', 'env_vars/docker.yml'])]) service=django
Traceback (most recent call last):
  File "/usr/local/bin/conductor", line 11, in <module>
    load_entry_point('ansible-container', 'console_scripts', 'conductor')()
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/cli.py", line 360, in conductor_commandline
    **params)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/cli.py", line 360, in conductor_commandline
    **params)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/core.py", line 738, in conductorcmd_build
    with_name=is_last_role)
  File "/_ansible/container/docker/engine.py", line 82, in __wrapped__
    return fn(self, *args, **kwargs)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/docker/engine.py", line 510, in commit_role_as_layer
    return to_commit.commit(**commit_data).id
  File "/usr/local/lib/python2.7/dist-packages/docker/models/containers.py", line 110, in commit
    **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/container.py", line 128, in commit
    return self._result(self._post_json(u, data=conf, params=params),
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 248, in _post_json
    return self._post(url, data=json.dumps(data2), **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 46, in inner
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 185, in _post
    return self.post(url, **self._set_request_timeout(kwargs))
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 549, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 502, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 612, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 516, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
```

###### After:

Adding COMPOSE_HTTP_TIMEOUT=300 in `conductor` settings `environment` directive allows entire build to complete as expected without timeout