### PR TITLE
Only break when key is not present

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,4 +57,5 @@ John R Barker <john@johnrbarker.com>
 Sidharth Surana <ssurana@vmware.com>
 grimmjow <ryanbrown.dev@gmail.com>
 Shea Stewart <shea.stewart@arctiq.ca>
+koralsky <karol.ossowski@gmail.com>
 Michael Carden <mike.carden@gmail.com>

--- a/container/config.py
+++ b/container/config.py
@@ -231,7 +231,7 @@ class BaseAnsibleContainerConfig(Mapping):
 
     def _validate_config(self, config):
         for key in self.REQUIRED_TOP_LEVEL_KEYS:
-            if not config.get(key):
+            if config.get(key, None) is None:
                 raise AnsibleContainerConfigException("Missing expected key '{}'".format(key))
 
         for top_level in config:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Testing for a required key fails when the key exists but returns a falsy value. This fix makes it so the test only fails when the key is actually missing.