### PR TITLE
Fixes #658 by adding ~/.ansible/roles to conductor ANSIBLE_ROLES_PATH

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -337,9 +337,9 @@ class Engine(BaseEngine, DockerSecretsMixin):
                 _add_var_list(conductor_settings['environment'])
 
         if roles_path:
-            environ['ANSIBLE_ROLES_PATH'] = "%s:/src/roles:/etc/ansible/roles" % (':').join(expanded_roles_path)
+            environ['ANSIBLE_ROLES_PATH'] = "%s:/src/roles:~/.ansible/roles:/etc/ansible/roles" % (':').join(expanded_roles_path)
         else:
-            environ['ANSIBLE_ROLES_PATH'] = '/src/roles:/etc/ansible/roles'
+            environ['ANSIBLE_ROLES_PATH'] = '/src/roles:~/.ansible/roles:/etc/ansible/roles'
 
         if params.get('devel'):
             conductor_path = os.path.dirname(container.__file__)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
With a `debian:jessie` conductor base from the latest develop commit, Ansible Galaxy is installing roles into a directory that ansible-container does not anticipate, and therefore builds with Galaxy roles in `requirements.yml` fail because the roles have been installed to, in my case `/root/.ansible/roles`, which is more generally `~/.ansible/roles` — but AC only expects roles to appear in `/src/roles` or `/etc/ansible/roles`, or else the mounted volume provided by `--roles-path` in the CLI.

This pull request simply adds `~/.ansible/roles` to the set of roles paths passed to the conductor.

See my comments on #658 for error output and description of the problem.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->