### PR TITLE
Remove broken "self" before Docker engine's "repository_prefix" reference

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -792,7 +792,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
         tag = tag or build_stamp
 
         if repository_prefix:
-            image_name = "{}-{}".format(self.repository_prefix, service_name)
+            image_name = "{}-{}".format(repository_prefix, service_name)
         elif repository_prefix is None:
             image_name = "{}-{}".format(self.project_name, service_name)
         elif repository_prefix == '':


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The variable `repository_prefix` has a `self` in front of it, but the variable is local scope rather than bound to the Engine class
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
###### Before

`ansible-container deploy --push-to my-registry`

```
Traceback (most recent call last):
  File "/usr/local/bin/conductor", line 11, in <module>
    load_entry_point('ansible-container', 'console_scripts', 'conductor')()
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/cli.py", line 392, in conductor_commandline
    **params)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/core.py", line 923, in conductorcmd_push
    password=password, repository_prefix=repository_prefix)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/docker/engine.py", line 795, in push
    image_name = "{}-{}".format(self.repository_prefix, service_name)
AttributeError: 'Engine' object has no attribute 'repository_prefix'
```

###### After

`repository_prefix` works as expected