### PR TITLE
Require Pip >= 6.0 for the match_markers method (#543)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Jinja2>=2.9
+pip>=6.0
 PyYAML>=3.12
 requests>=2
 ruamel.yaml>=0.14.2


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
For a source code installation of Ansible-Container to work on older operating systems (specially for the "match_markers" function), at least version 6.0 of Pip is required.

Fixes #543 