### PR TITLE
Add conductor environment during build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Bruce Becker <brucellino@gmail.com>
 Jeff Geerling <geerlingguy@mac.com>
 Marc Sensenich <marc-sensenich@users.noreply.github.com>
 Evan Zeimet <evan.zeimet@cdw.com>
+ekultails <ekultails@gmail.com>
 John Matthews <jwmatthews@gmail.com>
 Sean Summers <ssummer3@nd.edu>
 Alex Yanchenko <alex@yanchenko.com>

--- a/container/core.py
+++ b/container/core.py
@@ -127,8 +127,7 @@ def hostcmd_init(base_path, project=None, force=False, **kwargs):
 
 
 @host_only
-def hostcmd_build(base_path, project_name, engine_name, vars_files=None,
-                 **kwargs):
+def hostcmd_build(base_path, project_name, engine_name, vars_files=None, **kwargs):
     conductor_cache = kwargs['cache'] and kwargs['conductor_cache']
     config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
     engine_obj = load_engine(['BUILD', 'RUN'],
@@ -151,6 +150,9 @@ def hostcmd_build(base_path, project_name, engine_name, vars_files=None,
                         env_vars.append('{}={}'.format(key, value))
                 else:
                     env_vars = environment
+            if kwargs.get('with_variables'):
+                env_vars += kwargs['with_variables']
+
             engine_obj.build_conductor_image(
                 base_path,
                 config.conductor_base,

--- a/container/core.py
+++ b/container/core.py
@@ -28,6 +28,8 @@ except ImportError:
     from pipes import quote
 
 import requests
+
+from six import iteritems
 from six.moves.urllib.parse import urljoin
 
 from .exceptions import AnsibleContainerAlreadyInitializedException,\
@@ -141,10 +143,19 @@ def hostcmd_build(base_path, project_name, engine_name, vars_files=None,
     if conductor_image_id is None or not kwargs.get('devel'):
         #TODO once we get a conductor running, figure out how to know it's running
         if engine_obj.CAP_BUILD_CONDUCTOR:
+            env_vars = []
+            if config.get('settings', {}).get('conductor', {}).get('environment', {}):
+                environment = config['settings']['conductor']['environment']
+                if isinstance(environment, dict):
+                    for key, value in iteritems(environment):
+                        env_vars.append('{}={}'.format(key, value))
+                else:
+                    env_vars = environment
             engine_obj.build_conductor_image(
                 base_path,
                 config.conductor_base,
-                cache=conductor_cache
+                cache=conductor_cache,
+                environment=env_vars
             )
         else:
             logger.warning(u'%s does not support building the Conductor image.',

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -825,7 +825,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
 
     @log_runs
     @host_only
-    def build_conductor_image(self, base_path, base_image, cache=True):
+    def build_conductor_image(self, base_path, base_image, cache=True, environment=[]):
         with utils.make_temp_dir() as temp_dir:
             logger.info('Building Docker Engine context...')
             tarball_path = os.path.join(temp_dir, 'context.tar')
@@ -874,7 +874,8 @@ class Engine(BaseEngine, DockerSecretsMixin):
                                        'conductor-dockerfile.j2', temp_dir,
                                        'Dockerfile',
                                        conductor_base=base_image,
-                                       docker_version=DOCKER_VERSION)
+                                       docker_version=DOCKER_VERSION,
+                                       environment=environment)
             tarball.add(os.path.join(temp_dir, 'Dockerfile'),
                         arcname='Dockerfile')
 

--- a/container/docker/templates/conductor-dockerfile.j2
+++ b/container/docker/templates/conductor-dockerfile.j2
@@ -1,6 +1,9 @@
 FROM {{ conductor_base }}
 ENV ANSIBLE_CONTAINER=1
 {% set distro = conductor_base.split(':')[0] %}
+{% for envar in environment %}
+ENV {{ envar }}
+{% endfor %}
 {% if distro in ["fedora"] %}
 RUN dnf update -y && \
     dnf install -y make gcc git python2 python2-devel curl rsync libffi-devel openssl-devel redhat-rpm-config python2-dnf tar redhat-rpm-config && \

--- a/container/engine.py
+++ b/container/engine.py
@@ -176,7 +176,7 @@ class BaseEngine(object):
         raise NotImplementedError()
 
     @host_only
-    def build_conductor_image(self, base_path, base_image, cache=True):
+    def build_conductor_image(self, base_path, base_image, cache=True, environment=[]):
         raise NotImplementedError()
 
     def get_runtime_volume_id(self, mount_point):


### PR DESCRIPTION
##### ISSUE TYPE
 - New feature

##### SUMMARY
Closes #566

Adds conductor environment variables defined in `container.yml` to the conductor image. Given the following in `container.yml`:

```
version: "2"
settings:

  conductor:
    base: centos:7
    environment:
      http_proxy: http://my.proxy.server:8000
      https_proxy: https://my.proxy.server:84300

  project_name: tstenv
```

The following ENV statements get added to the build Dockerfile:

```
Step 1/14 : FROM centos:7
 ---> 328edcd84f1b
Step 2/14 : ENV ANSIBLE_CONTAINER 1
 ---> Using cache
 ---> 2066daf83ee0
Step 3/14 : ENV http_proxy http://my.proxy.server:8000
 ---> Running in 9a36c1421e69
 ---> 892f46c876ef
Removing intermediate container 9a36c1421e69
Step 4/14 : ENV https_proxy https://my.proxy.server:84300
 ---> Running in 707d5fa56a08
 ---> 249df1272120
```