### PR TITLE
Mount secrets consistent with Kubernetes

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -178,6 +178,10 @@ class Engine(BaseEngine, DockerSecretsMixin):
                 break
         return result
 
+    @property
+    def secrets_mount_path(self):
+        return os.path.join(os.sep, 'run', 'secrets')
+
     def container_name_for_service(self, service_name):
         return u'%s_%s' % (self.project_name, service_name)
 
@@ -263,7 +267,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
         if command != 'destroy' and self.CAP_SIM_SECRETS:
             self.create_secret_volume()
             volumes[self.secrets_volume_name] = {
-                'bind': '/run/secrets',
+                'bind': self.secrets_mount_path,
                 'mode': 'rw'
             }
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Make Docker mount secrets in a manor consistent with Kubernetes.

Given the following in `container.yml`:

```
...
services:
  web:
    ....
    secrets:
          postgres:
            docker:
              - postgres_user
              - postgres_password
            k8s:
              - mount_path: '/run/secrets'
                read_only: true

secrets:
   cloudsql:
     instance_credentials: cloudsql_key
   postgres:
     user: postgres_user
     password: postgres_password
```

The following is generated in the `run` playbook:

```
tasks:
      - shell: mkdir -p /run/secrets/postgres && echo '{{ postgres_password }}' >/run/secrets/postgres/password
        name: Write secret to Docker volume
        tags:
          - start
          - restart
          - stop
      - shell: mkdir -p /run/secrets/postgres && echo '{{ postgres_user }}' >/run/secrets/postgres/user
        name: Write secret to Docker volume
        tags:
          - start
          - restart
          - stop
      - shell: mkdir -p /run/secrets/cloudsql && echo '{{ cloudsql_key }}' >/run/secrets/cloudsql/instance_credentials
        name: Write secret to Docker volume
        tags:
          - start
          - restart
          - stop
```

The top-level secret name becomes a subdirectory under `/run/secrets` (the default place where Docker mounts secrets), and each key surfaces as a file within the subdirectory.