### PR TITLE
Add CLI options to specify /src mount path and volume driver

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -150,6 +150,10 @@ class HostCommand(object):
                                     u'into target containers in order to run Ansible. Use when the target '
                                     u'already has an installed Python runtime.',
                                dest='local_python', default=False)
+        subparser.add_argument('--src-mount-path', action='store',
+                               help=u'Specify the host path that should be mounted to the conductor at /src.'
+                                    u'Defaults to the directory from which ansible-container was invoked.',
+                               dest='src_mount_path', default=None)
         subparser.add_argument('ansible_options', action='store',
                                help=u'Provide additional commandline arguments to '
                                     u'Ansible in executing your playbook. If you '

--- a/container/cli.py
+++ b/container/cli.py
@@ -71,6 +71,10 @@ class HostCommand(object):
                                    help=u'Mount one or more volumes to the Conductor. '
                                         u'Specify volumes as strings using the Docker volume format.',
                                    default=[])
+            subparser.add_argument('--volume-driver', action='store',
+                                   help=u'Specify volume driver to use when mounting named volumes '
+                                        u'to the Conductor.',
+                                   default=None)
             subparser.add_argument('--with-variables', '-e', action='store', nargs='+',
                                    help=u'Define one or more environment variables in the '
                                         u'Conductor. Format each variable as a key=value string.',

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -291,7 +291,11 @@ class Engine(BaseEngine, DockerSecretsMixin):
             params['vault_files'] = vault_paths
 
         permissions = 'ro' if command != 'install' else 'rw'
-        volumes[base_path] = {'bind': '/src', 'mode': permissions}
+        if params.get('src_mount_path'):
+            src_path = params['src_mount_path']
+        else:
+            src_path = base_path
+        volumes[src_path] = {'bind': '/src', 'mode': permissions}
 
         if params.get('deployment_output_path'):
             deployment_path = params['deployment_output_path']

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -387,6 +387,10 @@ class Engine(BaseEngine, DockerSecretsMixin):
         # require privileged=True
         run_kwargs['privileged'] = True
 
+        # Support optional volume driver for mounting named volumes to the Conductor
+        if params.get('volume_driver'):
+            run_kwargs['volume_driver'] = params['volume_driver']
+
         logger.debug('Docker run:', image=image_id, params=run_kwargs)
         try:
             container_obj = self.client.containers.run(

--- a/container/k8s/base_engine.py
+++ b/container/k8s/base_engine.py
@@ -155,7 +155,7 @@ class K8sBaseEngine(DockerEngine):
                         )
                     image_tag = tag or self.get_build_stamp_for_image(image_id)
                     if repository_prefix:
-                        image_name = "{}-{}".format(self.repository_prefix, service_name)
+                        image_name = "{}-{}".format(repository_prefix, service_name)
                     elif repository_prefix is None:
                         image_name = "{}-{}".format(self.project_name, service_name)
                     elif repository_prefix == '':

--- a/docs/rst/reference/build.rst
+++ b/docs/rst/reference/build.rst
@@ -50,6 +50,14 @@ Define one or more environment variables in the Conductor container. Format each
 
 Mount one or more volumes to the Conductor container. Specify volumes as strings using the Docker volume format.
 
+.. option:: --src-mount-path SRC_MOUNT_PATH
+
+Specify the host path that should be mounted to the conductor at /src. Defaults to the directory from which ansible-container was invoked.
+
+.. option:: --volume-driver VOLUME_DRIVER
+
+Specify volume driver to use when mounting named volumes to the Conductor.
+
 .. option:: --roles-path ROLES_PATH [ROLES_PATH ...]
 
 If using roles not found in the ``roles`` directory within the project, use this option to specify one or more local paths containing the roles. The specified path(s) will be mounted to the conductor container, making the roles available to the build process.


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I'm attempting to setup Docker-out-of-Docker (i.e. mounting `/var/run/docker.sock`) in my Dockerized Jenkins CI environment, and found that (because Docker volume mounts via the socket always refer to host paths) I could not get the working directory (which is inside a Docker container) to mount into the sibling conductor container as `/src`.

To solve this, I need to mount `/src` with the path to my Jenkins `$JENKINS_HOME/workspace` on the **host** rather than the path to the workspace on the Jenkins build container.

This pull request adds an optional CLI flag to the `build` step, which overrides `base_path` in `engine.py` when mounting `/src` with the provided path

If the flag is not provided, `base_path` is mounted as usual.

I also added a flag to support the same Jenkins workflow, which supports mounting named volumes managed outside of Docker local host volume driver.

Also I caught another broken `self` reference in the k8s engine...

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
##### Proposed syntax

```
ansible-container build --src-mount-path /path/to/project/on/docker/host

ansilbe-container build --volume-driver rancher-nfs
```
