### PR TITLE
Require the Docker >= 2.4.0 Python library (#564)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,7 +42,7 @@ Ted Timmons <ted@perljam.net>
 Bruce Becker <brucellino@gmail.com>
 Jeff Geerling <geerlingguy@mac.com>
 Evan Zeimet <evan.zeimet@cdw.com>
-ekultails <ekultails@gmail.com>
+Luke Short <ekultails@gmail.com>
 John Matthews <jwmatthews@gmail.com>
 Sean Summers <ssummer3@nd.edu>
 Alex Yanchenko <alex@yanchenko.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-docker>=2.4.0
 Jinja2>=2.9
 pip>=6.0
 PyYAML>=3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docker>=2.4.0
 Jinja2>=2.9
 pip>=6.0
 PyYAML>=3.12

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,11 @@ if container.ENV == 'host':
         tests_require=[
             'ansible>=2.3.0',
             'pytest>=3',
-            'docker>=2.1',
+            'docker>=2.4.0',
             'jmespath>=0.9'
         ],
         extras_require={
-            'docker': ['docker>=2.1'],
+            'docker': ['docker>=2.4.0'],
             'docbuild': ['Sphinx>=1.5.0'],
             'openshift': ['openshift==0.0.1'],
             'k8s': ['openshift==0.0.1']


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
A bug in the Python library "docker" before 2.4.0 prevented images from correctly being used as `docker` would always look for the name "a"

Fixes #564 