### PR TITLE
Added support for override command directive when conductor is building image

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -731,6 +731,9 @@ def conductorcmd_build(engine_name, project_name, services, cache=True, local_py
                     environment=dict(ANSIBLE_CONTAINER=1)
                 )
 
+                if service.get('build_command'):
+                    run_kwargs['command'] = service['build_command']
+
                 if service.get('volumes'):
                     for volume in service['volumes']:
                         pieces = volume.split(':')


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY

Added support for override command directive when conductor is building image with systemd as pid 1. (feature idea  #399)

Default command when conductor use to run docker when building image is

`sh -c "while true; do sleep 1; done`

This PR will allow user to override it with `build_command` in each service.

```
version: 2

settings:
  project_name: test
  conductor:
    base: centos:7

services:
  grafana:
    from: centos/systemd
    roles:
      - grafana
    volumes:
      - /sys/fs/cgroup:/sys/fs/cgroup:ro
    stop_signal: SIGRTMIN+3
    cap_add: ["SYS_ADMIN"]
    command: /usr/sbin/init
    tty: true
    build_command: /usr/sbin/init
```
