### PR TITLE
Reduce Conductor base image sizes by like 25%.

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -948,6 +948,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
         utils.jinja_render_to_temp(TEMPLATES_PATH,
                                    'conductor-local-dockerfile.j2', temp_dir,
                                    'Dockerfile',
+                                   original_base=base_image,
                                    conductor_base=conductor_base,
                                    docker_version=DOCKER_VERSION)
         tarball.add(os.path.join(temp_dir, 'Dockerfile'),

--- a/container/docker/templates/conductor-local-dockerfile.j2
+++ b/container/docker/templates/conductor-local-dockerfile.j2
@@ -1,7 +1,14 @@
 FROM {{ conductor_base }}
+{% set distro = original_base.split(':')[0] %}
+
+VOLUME /usr
+{% if distro in ["ubuntu", "debian", "alpine"] %}
+VOLUME /lib
+{% endif %}
 
 # The COPY here will break cache if the requirements or ansible.cfg has changed
 COPY /build-src /_ansible/build
 RUN ( test -f /_ansible/build/ansible-requirements.txt && pip install --no-cache-dir -r /_ansible/build/ansible-requirements.txt || true ) && \
     ( test -f /_ansible/build/requirements.yml && ansible-galaxy install -p /etc/ansible/roles -r /_ansible/build/requirements.yml || true ) && \
     ( test -f /_ansible/build/ansible.cfg && cp /_ansible/build/ansible.cfg /etc/ansible/ansible.cfg || true)
+

--- a/container/docker/templates/conductor-src-dockerfile.j2
+++ b/container/docker/templates/conductor-src-dockerfile.j2
@@ -13,7 +13,7 @@ RUN dnf update -y && \
 RUN yum update -y && \
     yum install -y epel-release && \
     yum install -y make gcc git python-devel curl rsync libffi-devel openssl-devel && \
-    yum remove -y python-chardet && \
+    # yum remove -y python-chardet && \
     yum clean all
 {% elif "rhel" in distro %}
 RUN yum -y update-minimal --disablerepo "*" \
@@ -42,39 +42,24 @@ RUN apt-get update -y && \
 RUN apk add --no-cache -U python-dev make git curl rsync libffi libffi-dev openssl openssl-dev gcc musl-dev tar openssh
 {% endif %}
 
-ADD https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz /tmp/docker.tgz
-ADD https://bootstrap.pypa.io/get-pip.py /tmp/get-pip.py
-RUN python /tmp/get-pip.py && \
+RUN (curl https://bootstrap.pypa.io/get-pip.py | python - --no-cache-dir ) && \
     mkdir -p /etc/ansible/roles /_ansible/src && \
-    curl https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz \
-    | tar -zxC /usr/local/bin/ --strip-components=1
+    (curl https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz \
+       | tar -zxC /usr/local/bin/ --strip-components=1 docker/docker )
 
-# The COPY here will break cache if the version of conductor changed
+# The COPY here will break cache if the version of Ansible Container changed
 COPY /container-src /_ansible/container
-# Fix: 'pip install six' is a temporary fix for setuptools==36.0.0 bug
 RUN cd /_ansible && \
-    pip install six && \
-    pip install -r container/conductor-build/conductor-requirements.txt && \
-    PYTHONPATH=. LC_ALL="en_US.UTF-8" python container/conductor-build/setup.py develop -v && \
+    pip install --no-cache-dir -r container/conductor-build/conductor-requirements.txt && \
+    PYTHONPATH=. LC_ALL="en_US.UTF-8" python container/conductor-build/setup.py develop -v -N && \
     ansible-galaxy install -p /etc/ansible/roles -r container/conductor-build/conductor-requirements.yml
 
 {% if distro in ["centos"] %}
 # Removing python-chardet removed yum-utils, and now that we're done pip-installing things,
 # we'll put it back.
-RUN yum install -y yum-utils && \
-    yum clean all
+#RUN yum install -y yum-utils && \
+#    yum clean all
 {% endif %}
 
-{% if distro in ["centos"] %}
-# Removing python-chardet removed yum-utils, and now that we're done pip-installing things,
-# we'll put it back.
-RUN yum install -y yum-utils && \
-    yum clean all
-{% endif %}
-
-VOLUME /usr
-{% if distro in ["ubuntu", "debian", "alpine"] %}
-VOLUME /lib
-{% endif %}
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature pull request

##### SUMMARY
The prebaked Conductors are... hefty. We're doing some things inefficiently. This PR reduces the images' sizes substantially.

e.g. Centos 7 prebake slims down from 595MB to 439MB.