### PR TITLE
Updated all instances of the text conductor-container to be container…

### DIFF
--- a/docs/rst/conductor.rst
+++ b/docs/rst/conductor.rst
@@ -39,9 +39,9 @@ You don't have to use our ready-built Conductor base images. You can build your
 own, if you like, or you can build your own derivative of ours. Any Conductor base
 image should:
 
-1. It should be named ``conductor-container-$DISTRO-$TAG:$ANSIBLE_CONTAINER_VERSION``,
+1. It should be named ``container-conductor-$DISTRO-$TAG:$ANSIBLE_CONTAINER_VERSION``,
    so if you're building a Conductor base for OpenSuse 42.3 using Ansible Container
-   1.0rc1, your Conductor base image should be named ``conductor-container-opensuse-42.3:1.0rc1``.
+   1.0rc1, your Conductor base image should be named ``container-conductor-opensuse-42.3:1.0rc1``.
 2. It should have the very latest Ansible and all of its dependencies.
 3. It should have Ansible Container inside of it, as well as the requirements
    defined in ``container/conductor-build/conductor-requirements.txt``.


### PR DESCRIPTION
... to be container-conductor. The conductor_base refers the use of "container-conductor" and images being pulled to generate the conductor from Ansible use the same.

ISSUE TYPE

Docs Pull Request
SUMMARY

The images being pulled to generate a default conductor use the: tag = 'container-conductor-%s:%s' % (base_image.replace(':', '-'), which are not properly reflected in the documents.

Changes as follows:
docs/rst/conductor.rst
42. It should be named container-conductor-$DISTRO-$TAG:$ANSIBLE_CONTAINER_VERSION,
44. 1.0rc1, your Conductor base image should be named container-conductor-opensuse-42.3:1.0rc1.

*Apparently I thought I could add a new commit on my last PR, when i should have reverted. I decided to close that one and redo this PR from scratch with only the docs update.