### PR TITLE
Handle case where role/meta/main.yml is an empty file.

### DIFF
--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -246,6 +246,8 @@ def get_role_fingerprint(role_name):
         meta_main_path = os.path.join(role_path, 'meta', 'main.yml')
         if os.path.exists(meta_main_path):
             meta_main = yaml.safe_load(open(meta_main_path))
+            if not meta_main:
+                yield None
             for dependency in meta_main.get('dependencies', []):
                 yield dependency.get('role', None)
         else:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
If a role contains an empty meta/main.yml file ansible-container errors with a "None has to attribute get" error. This is because yaml.safe_load() can return None but this case is not handled. This pull request handles that case.
