### PR TITLE
Detect errors during local build

### DIFF
--- a/container/docker/templates/conductor-local-dockerfile.j2
+++ b/container/docker/templates/conductor-local-dockerfile.j2
@@ -8,7 +8,8 @@ VOLUME /lib
 
 # The COPY here will break cache if the requirements or ansible.cfg has changed
 COPY /build-src /_ansible/build
-RUN ( test -f /_ansible/build/ansible-requirements.txt && pip install --no-cache-dir -r /_ansible/build/ansible-requirements.txt || true ) && \
-    ( test -f /_ansible/build/requirements.yml && ansible-galaxy install -p /etc/ansible/roles -r /_ansible/build/requirements.yml || true ) && \
-    ( test -f /_ansible/build/ansible.cfg && cp /_ansible/build/ansible.cfg /etc/ansible/ansible.cfg || true)
+
+{% if install_requirements %}
+RUN {{ install_requirements }}
+{% endif %}
 

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -308,3 +308,29 @@ def list_to_ordereddict(config):
             result[key] = value
     return result
 
+@container.host_only
+def roles_to_install(base_path):
+    path = os.path.join(base_path, 'requirements.yml')
+    if os.path.exists(path) and os.path.isfile(path):
+        roles = yaml.safe_load(open(path, 'ro'))
+        if roles:
+            return True
+    return False
+
+
+@container.host_only
+def modules_to_install(base_path):
+    path = os.path.join(base_path, 'ansible-requirements.txt')
+    if os.path.exists(path) and os.path.isfile(path):
+        with open(path, 'ro') as fs:
+            line = fs.read().strip()
+            if not line.startswith('#'):
+                return True
+    return False
+
+@container.host_only
+def ansible_config_exists(base_path):
+    path = os.path.join(base_path, 'ansible.cfg')
+    if os.path.exists(path) and os.path.isfile(path):
+        return True
+    return False


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
If a role install fails, or a Python dependency fails, raise an error and stop the local Conductor build.  

Closes #740