### PR TITLE
Create config file before build

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -34,7 +34,7 @@ from container import host_only, conductor_only
 from container.engine import BaseEngine
 from container import utils, exceptions
 from container.utils import (logmux, text, ordereddict_to_list, roles_to_install, modules_to_install,
-                             ansible_config_exists)
+                             ansible_config_exists, create_file)
 from .secrets import DockerSecretsMixin
 
 try:
@@ -399,6 +399,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
 
         if command in ('login', 'push', 'build'):
             config_path = params.get('config_path') or self.auth_config_path
+            create_file(config_path, '{}')
             volumes[config_path] = {'bind': config_path,
                                     'mode': 'rw'}
 

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -36,7 +36,8 @@ __all__ = ['conductor_dir', 'make_temp_dir', 'get_config', 'assert_initialized',
            'metadata_to_image_config', 'create_role_from_templates',
            'resolve_role_to_path', 'get_role_fingerprint', 'get_content_from_role',
            'get_metadata_from_role', 'get_defaults_from_role', 'text',
-           'ordereddict_to_list', 'list_to_ordereddict']
+           'ordereddict_to_list', 'list_to_ordereddict', 'modules_to_install',
+           'roles_to_install', 'ansible_config_exists', 'create_file']
 
 conductor_dir = os.path.dirname(container.__file__)
 make_temp_dir = MakeTempDir
@@ -317,7 +318,6 @@ def roles_to_install(base_path):
             return True
     return False
 
-
 @container.host_only
 def modules_to_install(base_path):
     path = os.path.join(base_path, 'ansible-requirements.txt')
@@ -334,3 +334,17 @@ def ansible_config_exists(base_path):
     if os.path.exists(path) and os.path.isfile(path):
         return True
     return False
+
+@container.host_only
+def create_file(file_path, contents):
+    if not os.path.exists(file_path):
+        try:
+            os.makedirs(os.path.dirname(file_path), mode=0o775)
+        except Exception:
+            pass
+
+        try:
+            with open(file_path, 'w') as fs:
+                fs.write(contents)
+        except Exception:
+            raise


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Make sure the Docker config file exists before mounting it to the Conductor container.

Closes #717