### PR TITLE
Python 3 compatibility: don't use unicode builtin

### DIFF
--- a/container/docker/config.py
+++ b/container/docker/config.py
@@ -25,7 +25,7 @@ class AnsibleContainerConfig(BaseAnsibleContainerConfig):
         except IOError:
             raise AnsibleContainerNotInitializedException()
         except yaml.YAMLError as exc:
-            raise AnsibleContainerConfigException(u"Parsing container.yml - %s" % unicode(exc))
+            raise AnsibleContainerConfigException(u"Parsing container.yml - %s" % exc)
 
         new_services = yaml.compat.ordereddict()
         for service_name, service_config in iteritems(config.get('services') or {}):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Exception `NameError: name 'unicode' is not defined` was raised when
`container.yml` is malformed. Tested with Python 3.5.4.

Without the fix:
```
$ ansible-container stop
ERROR	Unknown exception	
Traceback (most recent call last):
  File "~/src/ansible-container/container/docker/config.py", line 24, in set_env
    config = yaml.round_trip_load(open(self.config_path))
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/main.py", line 685, in round_trip_load
    return load(stream, RoundTripLoader, version, preserve_quotes=preserve_quotes)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/main.py", line 636, in load
    return loader._constructor.get_single_data()  # type: ignore
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/constructor.py", line 102, in get_single_data
    node = self.composer.get_single_node()
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 75, in get_single_node
    document = self.compose_document()
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 96, in compose_document
    node = self.compose_node(None, None)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 132, in compose_node
    node = self.compose_mapping_node(anchor)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 194, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 132, in compose_node
    node = self.compose_mapping_node(anchor)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 194, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 132, in compose_node
    node = self.compose_mapping_node(anchor)
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/composer.py", line 187, in compose_mapping_node
    while not self.parser.check_event(MappingEndEvent):
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/parser.py", line 144, in check_event
    self.current_event = self.state()
  File "~/venv/ac/lib/python3.5/site-packages/ruamel/yaml/parser.py", line 561, in parse_block_mapping_key
    token.start_mark)
ruamel.yaml.parser.ParserError: while parsing a block mapping
  in "~/src/ansible-maint/deploy/container.yml", line 55, column 5
expected <block end>, but found '<block mapping start>'
  in "~/src/ansible-maint/deploy/container.yml", line 58, column 6

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "~/src/ansible-container/container/cli.py", line 299, in __call__
    getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
  File "~/src/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "~/src/ansible-container/container/core.py", line 297, in hostcmd_stop
    config = get_config(base_path, vars_files=vars_files, engine_name=engine_name, project_name=project_name)
  File "~/src/ansible-container/container/utils/__init__.py", line 50, in get_config
    project_name=project_name, vault_files=vault_files)
  File "~/src/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "~/src/ansible-container/container/config.py", line 62, in __init__
    self.set_env('prod')
  File "~/src/ansible-container/container/docker/config.py", line 28, in set_env
    raise AnsibleContainerConfigException(u"Parsing container.yml - %s" % unicode(exc))
NameError: name 'unicode' is not defined
```

With this pull request applied:
```
$ ansible-container stop
ERROR	Invalid container.yml: Parsing container.yml - while parsing a block mapping
  in "~/src/ansible-maint/deploy/container.yml", line 55, column 5
expected <block end>, but found '<block mapping start>'
```