### PR TITLE
Run and restart specific services

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -148,6 +148,14 @@ class BaseAnsibleContainerConfig(Mapping):
         logger.debug(u"Parsed config", config=config)
         self._config = config
 
+    def set_services(self, services):
+        if not services:
+            return
+        remove_services = list(set(self._config['services']) - set(services))
+        if remove_services:
+            for service in remove_services:
+                del self._config['services'][service]
+
     def _update_service_config(self, env, service_config):
         if isinstance(service_config, dict):
             dev_overrides = service_config.pop('dev_overrides', {})

--- a/container/core.py
+++ b/container/core.py
@@ -11,7 +11,6 @@ import getpass
 import gzip
 import hashlib
 import io
-import json
 import os
 import re
 import ruamel
@@ -240,6 +239,9 @@ def hostcmd_run(base_path, project_name, engine_name, vars_files=None, cache=Tru
     if not kwargs['production']:
         config.set_env('dev')
 
+    services = kwargs.pop('service')
+    config.set_services(services)
+
     logger.debug('hostcmd_run configuration', config=config.__dict__)
 
     engine_obj = load_engine(['RUN'],
@@ -321,6 +323,9 @@ def hostcmd_restart(base_path, project_name, engine_name, vars_files=None, force
     config = get_config(base_path, vars_files=vars_files, engine_name=engine_name,  project_name=project_name)
     if not kwargs['production']:
         config.set_env('dev')
+
+    services = kwargs.pop('service')
+    config.set_services(services)
 
     engine_obj = load_engine(['RUN'],
                              engine_name, config.project_name,


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Restore missing functionality. Now you can `ansible-container start <service>` and `ansible-container restart <service>`.

Fixes #764 