### PR TITLE
Nicer DockerExceptions

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -320,6 +320,10 @@ class HostCommand(object):
         except exceptions.AnsibleContainerDockerConnectionRefused:
             logger.error('The connection to Docker was refused. Check your Docker environment configuration.',
                          exc_info=False)
+        except exceptions.AnsibleContainerDockerConnectionAborted as e:
+            logger.error('The connection to Docker was aborted. Check your Docker environment configuration.\n'
+                         'ErrorMessage: %s' % str(e),
+                         exc_info=False)
             sys.exit(1)
         except exceptions.AnsibleContainerConfigException as e:
             logger.error('Invalid container.yml: {}'.format(e), exc_info=False)

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -166,6 +166,8 @@ class Engine(BaseEngine, DockerSecretsMixin):
             except DockerException as exc:
                 if 'Connection refused' in str(exc):
                     raise exceptions.AnsibleContainerDockerConnectionRefused()
+                elif 'Connection aborted' in str(exc):
+                    raise exceptions.AnsibleContainerDockerConnectionAborted(u"%s" % str(exc))
                 else:
                     raise
         return self._client

--- a/container/exceptions.py
+++ b/container/exceptions.py
@@ -32,6 +32,9 @@ class AnsibleContainerDockerLoginException(AnsibleContainerException):
 class AnsibleContainerDockerConnectionRefused(AnsibleContainerException):
     pass
 
+class AnsibleContainerDockerConnectionAborted(AnsibleContainerException):
+    pass
+
 class AnsibleContainerConfigException(AnsibleContainerException):
     pass
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added exceptionclass AnsibleContainerDockerConnectionAborted for Docker "Connection aborted" messages which occur when
 - docker.sock is not present
 - the user doesn't have the needed privileges

Fixes #755 and #710 

```
#ErrorMessage for /var/run/docker.sock not present:
ERROR   The connection to Docker was aborted. Check your Docker environment configuration.
ErrorMessage: Error while fetching server API version: ('Connection aborted.', error(2, 'No such file or directory'))

#ErrorMessage for missing permissions now
ERROR   The connection to Docker was aborted. Check your Docker environment configuration.
ErrorMessage: Error while fetching server API version: ('Connection aborted.', error(13, 'Permission denied'))
```
