### PR TITLE
Handle undefined environment variables

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -113,6 +113,38 @@ class BaseAnsibleContainerConfig(Mapping):
         # When pushing images or deploying, we need to know the default namespace
         pass
 
+    def get_conductor_environment(self):
+        """
+        Return a copy of settings.conductor.environment + any undefined variables found in the service definitions.
+        Attempts to set undefined variables from a corresponding values found in the local environment. 
+        """  
+        conductor_env = copy.deepcopy(self._config.get('settings', {}).get('conductor', {}).get('environment', {}))
+        if isinstance(conductor_env, list):
+            # convert to a dict 
+            new_env = {}
+            for item in [e.split('=', 1) for e in conductor_env if '=' in e]:
+                new_env[item[0]] = item[1]
+            conductor_env = new_env
+        
+        for name, options in iteritems(self._config['services']):
+            if options.get('environment'):
+                if isinstance(options['environment'], list):
+                    for e in options['environment']:
+                        if '=' not in e and os.environ.get(e) and not conductor_env.get(e):
+                            conductor_env[e] = os.environ[e]
+                elif isinstance(options['environment'], dict):
+                    for key, value in iteritems(options['environment']):
+                        if value is None and os.environ.get(key) and not conductor_env.get(key):
+                            conductor_env[key] = os.environ[key]    
+        return conductor_env 
+
+    def set_conductor_environment(self, environment):
+        if self._config.get('settings') is None: 
+            self._config['settings'] = {}
+        if self._config['settings'].get('conductor') is None:
+            self._config['settings']['conductor'] = {}
+        self._config['settings']['conductor']['environment'] = environment
+
     @abstractmethod
     def set_env(self, env, config=None):
         """

--- a/container/core.py
+++ b/container/core.py
@@ -246,6 +246,8 @@ def hostcmd_run(base_path, project_name, engine_name, vars_files=None, cache=Tru
     services = kwargs.pop('service')
     config.check_requested_services(services)
     config.set_services(services)
+    conductor_env = config.get_conductor_environment() 
+    config.set_conductor_environment(conductor_env)
 
     logger.debug('hostcmd_run configuration', config=config.__dict__)
 
@@ -259,7 +261,7 @@ def hostcmd_run(base_path, project_name, engine_name, vars_files=None, cache=Tru
         'deployment_output_path': config.deployment_path,
         'host_user_uid': os.getuid(),
         'host_user_gid': os.getgid(),
-        'settings': config.get('settings', {})
+        'settings': config.get('settings', {}), 
     }
     if kwargs:
         params.update(kwargs)
@@ -336,6 +338,8 @@ def hostcmd_restart(base_path, project_name, engine_name, vars_files=None, force
     services = kwargs.pop('service')
     config.check_requested_services(services)
     config.set_services(services)
+    conductor_env = config.get_conductor_environment()
+    config.set_conductor_environment(conductor_env)
 
     engine_obj = load_engine(['RUN'],
                              engine_name, config.project_name,

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -112,7 +112,7 @@ def metadata_to_image_config(metadata):
         )
         if isinstance(environment, list):
             environment = {k: v for (k, v) in
-                           [item.split('=', 1) for item in environment]}
+                           [item.split('=', 1) for item in environment if '=' in item]}
         to_return.update(environment)
         return ['='.join(tpl) for tpl in iteritems(to_return)]
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
During `run` and `restart` (within the context of the docker engine), if an environment variable at the service level is defined as null or None, we should mimic the behavior of Docker Compose, and use the value of any corresponding variable found in the local environment.

For example, consider the following `container.yml`:

```
version: '2'
services:
  web:
    environment:
      FOO:
...
```

The variable `FOO` does not have a definition, and so in Docker Compose it's definition would come from the local environment. In our case, however, the local environment is the Conductor, which contains no definition for `FOO`.

This PR addresses this by looking in the local environment for `FOO`, and if a value is found, adds it to settings.conductor.environment. If there is already a value for `FOO` found in settings.conductor.environment, it will not be replaced.

And for bonus points, if a variable is found on settings.conductor.environment without a value, this PR checks for a value in the local environment, and passes it along.

Closes #779 


