### PR TITLE
extra_hosts now works on docker

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -760,6 +760,9 @@ class Engine(BaseEngine, DockerSecretsMixin):
                         service_definition['volumes'] = []
                     service_definition['volumes'].append("{}:/run/secrets:ro".format(self.secrets_volume_name))
 
+            if 'extra_hosts' in service:
+                service_definition['extra_hosts'] = service['extra_hosts']
+
             logger.debug(u'Adding new service to definition',
                          service=service_name, definition=service_definition)
             service_def[service_name] = service_definition


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Ansible-Container was ignoring the `extra_hosts` setting from `container.yml`.

Fortunatelly it was an easy fix: all I had to do was to pass this setting inside of 

`container/docker/engine.py generate_orchestration_playbook()`

So now all my containers have `extra_hosts` !
