### PR TITLE
extra_hosts now works on docker

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -760,6 +760,9 @@ class Engine(BaseEngine, DockerSecretsMixin):
                         service_definition['volumes'] = []
                     service_definition['volumes'].append("{}:/run/secrets:ro".format(self.secrets_volume_name))
 
+            if 'extra_hosts' in service:
+                service_definition['extra_hosts'] = service['extra_hosts']
+
             logger.debug(u'Adding new service to definition',
                          service=service_name, definition=service_definition)
             service_def[service_name] = service_definition

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -141,7 +141,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
     COMPOSE_WHITELIST = (
         'links', 'depends_on', 'cap_add', 'cap_drop', 'command', 'devices',
         'dns', 'dns_opt', 'tmpfs', 'entrypoint', 'environment', 'expose',
-        'external_links', 'labels', 'links', 'logging', 'log_opt', 'networks',
+        'external_links', 'extra_hosts', 'labels', 'links', 'logging', 'log_opt', 'networks',
         'network_mode', 'pids_limit', 'ports', 'security_opt', 'stop_grace_period',
         'stop_signal', 'sysctls', 'ulimits', 'userns_mode', 'volumes',
         'volume_driver', 'volumes_from', 'cpu_shares', 'cpu_quota', 'cpuset',
@@ -759,9 +759,6 @@ class Engine(BaseEngine, DockerSecretsMixin):
                     if not 'volumes' in service_definition:
                         service_definition['volumes'] = []
                     service_definition['volumes'].append("{}:/run/secrets:ro".format(self.secrets_volume_name))
-
-            if 'extra_hosts' in service:
-                service_definition['extra_hosts'] = service['extra_hosts']
 
             logger.debug(u'Adding new service to definition',
                          service=service_name, definition=service_definition)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Ansible-Container was ignoring the `extra_hosts` setting from `container.yml`.

Fortunatelly it was an easy fix: all I had to do was to pass this setting inside of 

`container/docker/engine.py generate_orchestration_playbook()`

So now all my containers have `extra_hosts` !
