### PR TITLE
Snapshot volumes as the last step in local conductors

### DIFF
--- a/container/docker/templates/conductor-local-dockerfile.j2
+++ b/container/docker/templates/conductor-local-dockerfile.j2
@@ -1,15 +1,15 @@
 FROM {{ conductor_base }}
 {% set distro = original_base.split(':')[0] %}
-
-VOLUME /usr
-{% if distro in ["ubuntu", "debian", "alpine"] %}
-VOLUME /lib
-{% endif %}
-
 # The COPY here will break cache if the requirements or ansible.cfg has changed
 COPY /build-src /_ansible/build
 
 {% if install_requirements %}
 RUN {{ install_requirements }}
 {% endif %}
+
+VOLUME /usr
+{% if distro in ["ubuntu", "debian", "alpine"] %}
+VOLUME /lib
+{% endif %}
+
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### SUMMARY

Fixes #809 

The local conductor image shouldn't snapshot `/usr` and `/lib` until all of the changes have been made to those file trees. This corrects that.