### PR TITLE
Don't bomb out on an empty vars file

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -300,7 +300,7 @@ class BaseAnsibleContainerConfig(Mapping):
                 config = json.load(open(abspath))
             except Exception as exc:
                 raise AnsibleContainerConfigException(u"JSON exception: %s" % text_type(exc))
-        return iteritems(config)
+        return iteritems(config) if config else []
 
     TOP_LEVEL_WHITELIST = [
         'version',


### PR DESCRIPTION
Fixes #797

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### SUMMARY
If a command-line specified vars file is empty, Ansible Container will error out. This fixes that behavior.