### PR TITLE
Fix service processing disable

### DIFF
--- a/container/config.py
+++ b/container/config.py
@@ -443,7 +443,7 @@ class AnsibleContainerConductorConfig(Mapping):
                 )
                 services[service]['defaults'] = service_defaults
             else:
-                services[service] = {}
+                services[service] = service_data
         self.services = services
 
     def __getitem__(self, key):

--- a/container/config.py
+++ b/container/config.py
@@ -411,10 +411,10 @@ class AnsibleContainerConductorConfig(Mapping):
 
     def _process_services(self):
         services = ordereddict()
-        if not self._skip_services:
-            for service, service_data in self._config.get('services', ordereddict()).items():
-                logger.debug('Processing service...', service=service, service_data=service_data)
-                processed = ordereddict()
+        for service, service_data in self._config.get('services', ordereddict()).items():
+            logger.debug('Processing service...', service=service, service_data=service_data)
+            processed = ordereddict()
+            if not self._skip_services:
                 service_defaults = self.defaults.copy()
                 for idx in range(len(service_data.get('volumes', []))):
                     # To mount the project directory, let users specify `$PWD` and
@@ -442,6 +442,8 @@ class AnsibleContainerConductorConfig(Mapping):
                     templar=Templar(loader=None, variables=service_defaults)
                 )
                 services[service]['defaults'] = service_defaults
+            else:
+                services[service] = {}
         self.services = services
 
     def __getitem__(self, key):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### SUMMARY
In trying to disable processing of variables/roles/etc. for commands that don't need the processed data (e.g. push), we were a little aggressive and simply disabled the inclusion of any services in the processed config, which means nothing would get pushed.

This corrects the correction. Thanks, @jimi-c! 