### PR TITLE
Dot i's and cross t's

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include container/templates *
 recursive-include container/docker/files *
 recursive-include container/docker/templates *
+include container/schema.yml
 include *.yml
 include *.txt
 include *.md

--- a/docs/rst/getting_started.rst
+++ b/docs/rst/getting_started.rst
@@ -45,6 +45,7 @@ Ansible Container provides a convenient way to start your app by simply running
     container.yml
     meta.yml
     requirements.yml
+    .dockerignore
 
 Other ``ansible-container`` subcommands enable the container development workflow:
 
@@ -144,6 +145,14 @@ Set Ansible configuration settings within the build container. For more
 information see `Configuration File <http://docs.ansible.com/ansible/intro_configuration.html>`_.
 Do note that overriding some of the settings, like `roles_path`, might have unexpected results,
 due to Ansible using the Conductor container as its execution environment.
+
+.dockerignore
+`````````````
+During a build, it is commonplace to synchronize the source from your project into
+one of your target containers. However many such files are not appropriate to be
+part of that build context, such as your ``.git`` directory. The Docker Engine would
+ignore files or patterns contained in the ``.dockerignore`` file from the build context
+and for conformity, Ansible Container will do the same.
 
 .. _example-project:
 

--- a/docs/rst/reference/build.rst
+++ b/docs/rst/reference/build.rst
@@ -7,6 +7,8 @@ The ``ansible-container build`` command starts the Conductor container, and runs
 
 Each playbook runs inside the Conductor, and executes tasks on the service container, using the Docker connection plugin. When finished, a commit is performed on the service container, the container is stopped, and an image is created for the service. At the end of a successful run of this command, a built image will exist for each custom service (i.e., a service defined with one or more Ansible roles). This is analogous to ``docker build``.
 
+During a build, your project's contents are provided as a build context in the Conductor container at the file path ``/src``. Any files or patterns specified in a ``.dockerignore`` file will not be included in this build context.
+
 .. option:: --flatten
 
 By default, Ansible Container commits the changes your playbook made to the base image, but it retains the original layers from that base image. Specifying this option, Ansible Container flattens the union filesystem of your image to a single layer. This does break caching, so builds won'e be able to reuse cached layers and will fully rebuild your services even if you haven't changed anything.


### PR DESCRIPTION
I missed a couple of small details in the previous two pull requests merged. This corrects the `MANIFEST.in` and documents the use of the `.dockerignore` file.