### PR TITLE
Fix role install

### DIFF
--- a/container/utils/galaxy.py
+++ b/container/utils/galaxy.py
@@ -18,7 +18,7 @@ from container.utils.visibility import getLogger
 
 logger = getLogger(__name__)
 
-ANSIBLE_CONTAINER_PATH = '/src'
+ANSIBLE_CONTAINER_PATH = '/_src'
 
 
 class AttrDict(dict):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
After the introduction of `.dockerignore`, the `install` command now needs to read and write at `/_src`.