### PR TITLE
Provide variable manager and loader to cache inspector

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,10 +14,10 @@ Eric D. Helms <ericdhelms@gmail.com>
 Dusty Mabe <dusty@dustymabe.com>
 Eric D Helms <eric.d.helms@gmail.com>
 Josiah Goodson <josiah.goodson@gmail.com>
+Tomas Tomecek <ttomecek@redhat.com>
 Dominik del Bondio <dominik.del.bondio@bitextender.com>
 Marcus Levine <marcusianl@gmail.com>
 Dylan Silva <thaumos@users.noreply.github.com>
-Tomas Tomecek <ttomecek@redhat.com>
 Fabian von Feilitzsch <fabianvf@users.noreply.github.com>
 Charlie Drage <charlie@charliedrage.com>
 Roderick Randolph <roderickrandolph@users.noreply.github.com>
@@ -28,6 +28,7 @@ Marius Gerling <marius.gerling@uniberg.com>
 Gerard Braad <me@gbraad.nl>
 ekultails <ekultails@gmail.com>
 Evgeni Golov <evgeni@golov.de>
+Yutaka Kohada <y.kohada@gmail.com>
 Joseph Callen <jcpowermac@gmail.com>
 Will Thames <wthames@redhat.com>
 Vadim Rutkovsky <roignac@gmail.com>

--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -288,7 +288,8 @@ def get_role_fingerprint(role, service_name, config_vars):
         # role, like source code
         loader = DataLoader()
         var_man = VariableManager(loader=loader)
-        play = Play.load(generate_playbook_for_role(service_name, config_vars, role)[0])
+        play = Play.load(generate_playbook_for_role(service_name, config_vars, role)[0],
+                         variable_manager=var_man, loader=loader)
         play_context = PlayContext(play=play)
         inv_man = InventoryManager(loader, sources=['%s,' % service_name])
         host = Host(service_name)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Fixes #858 by making the role cache checker use Ansible primitives properly.
```
# container.yml
version: "2"
settings:
  conductor:
    base: centos:7
  project_name: i858
services:
  test:
    from: centos:7
    roles:
      - i858

# roles/i858/tasks/main.yml
---
- debug: msg=main
- include_tasks: "other.yml"

# roles/i858/tasks/other.yml
---
- debug: msg=included

$ ansible-container --devel build --no-cache
Building Docker Engine context...	
Starting Docker build of Ansible Container Conductor image (please be patient)...
Parsing conductor CLI args.
Copying build context into Conductor container.
Docker™ daemon integration engine loaded. Build starting.	project=i858
Building service...	project=i858 service=test
Fingerprint for this layer: 043ab19711de4e7d57ba55d54598b92e9c7219c0b40fe5de73f0078d48f791ef	parent_fingerprint=7ad9462067e7decb4b90d672399ca17f02fd05c011bc31ec275bcffc4a189e52 parent_image_id=sha256:ff426288ea903fcf8d91aca97460c613348f7a27195606b45f19ae91776ca23d role=i858 service=test
Applying role i858 on image sha256:ff426288ea903fcf8d91aca97460c613348f7a27195606b45f19ae91776ca23d as container i858_test-7ad94620-i858	service=test

PLAY [test] ********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [test]

TASK [i858 : debug] ************************************************************
ok: [test] => {
    "msg": "main"
}

TASK [i858 : include_tasks] ****************************************************
included: /src/roles/i858/tasks/other.yml for test

TASK [i858 : debug] ************************************************************
ok: [test] => {
    "msg": "included"
}

PLAY RECAP *********************************************************************
test                       : ok=4    changed=0    unreachable=0    failed=0

Applied role to service	role=i858 service=test
Committed layer as image	fingerprint=043ab19711de4e7d57ba55d54598b92e9c7219c0b40fe5de73f0078d48f791ef image=sha256:898fc3f001477007c49b877615f7f501f68a13b74f88d319f78a58837e31447f role=i858 service=test
Build complete.	service=test
Cleaning up stale build artifacts.	service=test
All images successfully built.
Conductor terminated. Cleaning up.	command_rc=0 conductor_id=4752011b0874a27392593e71955419f7077351f1647e39b227d36b6f1ca2a76c save_container=False


```
