### PR TITLE
Fixes to import regexes around variable containing values

### DIFF
--- a/container/docker/importer.py
+++ b/container/docker/importer.py
@@ -285,7 +285,7 @@ class DockerfileParser(object):
 
     def parse_EXPOSE(self, payload, comments):
         # Ensure all variable references are quoted, so we can use shlex
-        payload = re.sub(r'(\{\{[^}]+\}\})', r'"\1"', payload)
+        payload = re.sub(r'(.*\{\{[^}]+\}\}.*)', r'"\1"', payload)
         ports = shlex.split(payload)
         self.meta.setdefault('ports', CommentedSeq()).extend(ports)
         self.meta.yaml_set_comment_before_after_key('ports',
@@ -302,7 +302,7 @@ class DockerfileParser(object):
                                                                        before=u'\n'.join(comments))
         else:
             # Ensure all variable references are quoted, so we can use shlex
-            payload = re.sub(r'=(\{\{[^}]+\}\})', r'="\1"', payload)
+            payload = re.sub(r'=(.*\{\{[^}]+\}\}.*)', r'="\1"', payload)
             kv_parts = shlex.split(payload)
             kv_pairs = [part.split(u'=', 1) for part in kv_parts]
             self.meta.setdefault('environment', CommentedMap()).update(kv_pairs)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Improvements to regular expressions around variable containing strings in imports. Fixes #835.
```
# Dockerfile
FROM centos:7
ENV JAVA_HOME=/usr/java/jdk1.8.0_152/jre/ \
  PATH=/opt/apache-maven-3.5.0/bin:${PATH} \
  M2_HOME=/opt/apache-maven-3.5.0

# imported result
from: centos:7
environment:
  JAVA_HOME: /usr/java/jdk1.8.0_152/jre/
  PATH: /opt/apache-maven-3.5.0/bin:{{ PATH }}
  M2_HOME: /opt/apache-maven-3.5.0

```
