### PR TITLE
Limited docker version - lower than 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,11 +84,11 @@ if container.ENV == 'host':
         tests_require=[
             'ansible>=2.3.0',
             'pytest>=3',
-            'docker>=2.4.0',
+            'docker>=2.4.0,<=2.7.0',
             'jmespath>=0.9'
         ],
         extras_require={
-            'docker': ['docker>=2.4.0'],
+            'docker': ['docker>=2.4.0,<=2.7.0'],
             'docbuild': ['Sphinx>=1.5.0'],
             'openshift': ['openshift==0.0.1'],
             'k8s': ['openshift==0.0.1']

--- a/setup.py
+++ b/setup.py
@@ -84,11 +84,11 @@ if container.ENV == 'host':
         tests_require=[
             'ansible>=2.3.0',
             'pytest>=3',
-            'docker>=2.4.0,<=2.7.0',
+            'docker>=2.4.0,<3.0.0',
             'jmespath>=0.9'
         ],
         extras_require={
-            'docker': ['docker>=2.4.0,<=2.7.0'],
+            'docker': ['docker>=2.4.0,<3.0.0'],
             'docbuild': ['Sphinx>=1.5.0'],
             'openshift': ['openshift==0.0.1'],
             'k8s': ['openshift==0.0.1']


### PR DESCRIPTION

Fixes #869 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
```
The change limits the version of docker installed by pip to be lower than 3.0.0
Becuase release 3.0.0 breaks ansible-container
```
<!---

-->

