### PR TITLE
Handle role with empty metadata file (fix AttributeError)

### DIFF
--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -310,12 +310,9 @@ def get_role_fingerprint(role, service_name, config_vars):
         meta_main_path = os.path.join(role_path, 'meta', 'main.yml')
         if os.path.exists(meta_main_path):
             meta_main = yaml.safe_load(open(meta_main_path))
-            if not meta_main:
-                yield None
-            for dependency in meta_main.get('dependencies', []):
-                yield dependency.get('role', None)
-        else:
-            yield None
+            if meta_main:
+                for dependency in meta_main.get('dependencies', []):
+                    yield dependency.get('role', None)
 
     hash_obj = hashlib.sha256()
     # Account for variables passed to the role by including the invocation string


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
The following exception occurs when a role with an empty metadata file is used.
```
Traceback (most recent call last):
  File "/usr/local/bin/conductor", line 11, in <module>
    load_entry_point('ansible-container', 'console_scripts', 'conductor')()
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/cli.py", line 423, in conductor_commandline
    **params)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/core.py", line 809, in conductorcmd_build
    role_fingerprint = get_role_fingerprint(role, service_name, config_vars)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/utils/__init__.py", line 326, in get_role_fingerprint
    hash_role(hash_obj, resolve_role_to_path(role))
  File "/_ansible/container/utils/__init__.py", line 286, in hash_role
    hash_role(hash_obj, dependency_path)
  File "/_ansible/container/utils/__init__.py", line 286, in hash_role
    hash_role(hash_obj, dependency_path)
  File "/_ansible/container/utils/__init__.py", line 283, in hash_role
    for dependency in get_dependencies_for_role(role_path):
  File "/_ansible/container/utils/__init__.py", line 317, in get_dependencies_for_role
    for dependency in meta_main.get('dependencies', []):
AttributeError: 'NoneType' object has no attribute 'get'
```