### PR TITLE
set requirements for k8s and openshift to use latest openshift package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,8 @@ if container.ENV == 'host':
         extras_require={
             'docker': ['docker>=2.4.0,<3.0'],
             'docbuild': ['Sphinx>=1.5.0'],
-            'openshift': ['openshift==0.0.1'],
-            'k8s': ['openshift==0.0.1']
+            'openshift': ['openshift>=0.0.1'],
+            'k8s': ['openshift>=0.0.1']
         },
         #dependency_links=[
         #    'https://github.com/ansible/ansible/archive/devel.tar.gz#egg=ansible-2.4.0',


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #881 
Use latest openshift pypi package instead of 0.0.1 for k8s and openshift engines
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
