### PR TITLE
replace characters that are unsafe in docker layer names with a "_"

### DIFF
--- a/container/core.py
+++ b/container/core.py
@@ -696,7 +696,8 @@ def _find_base_image_id(engine, service_name, service):
     return image_id
 
 def _intermediate_build_container_name(engine, service_name, image_fingerprint, role_name):
-    return u'%s-%s-%s' % (engine.container_name_for_service(service_name), image_fingerprint[:8], role_name)
+    safe_role_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", role_name);
+    return u'%s-%s-%s' % (engine.container_name_for_service(service_name), image_fingerprint[:8], safe_role_name)
 
 def _run_intermediate_build_container(engine, container_name, cur_image_id, service_name, service,
                                       **kwargs):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
If ansible-container has a path to a role directory that is nested (e.g., roles/some/path/to/role/) it ends up trying to use a layer name that is invalid in Docker.

Docker layer names may not contain characters outside the range [a-zA-Z0-9_.-].

This patch replaces all characters outside the allowed range with underscores.