### PR TITLE
docker 3.0.0 and up return a generator from export

### DIFF
--- a/conductor-requirements.txt
+++ b/conductor-requirements.txt
@@ -1,6 +1,7 @@
 ansible>=2.4,<2.5
 https://github.com/openshift/openshift-restclient-python/archive/master.tar.gz#egg=openshift
 PyYAML>=3.12
+docker>=3.0.0
 docker-compose>=1.14
 requests>=2,<2.16
 ruamel.yaml>=0.15.34

--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -691,8 +691,8 @@ class Engine(BaseEngine, DockerSecretsMixin):
 
         logger.debug("Exported service container as tarball", container=image_name)
 
-        out = self.client.api.import_image_from_data(
-            raw_image.read(),
+        out = self.client.api.import_image_from_stream(
+            raw_image,
             repository=image_name,
             tag=image_version
         )


### PR DESCRIPTION
Use the new stream importer to feed it right back.

##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
docker>=3.1.4 is getting pulled in by the unbounded dependency on docker-compose. Docker 3.0.0 and up return a generator from container.export(), resulting in a traceback
```
Traceback (most recent call last):
  File "/usr/bin/conductor", line 11, in <module>
    load_entry_point('ansible-container==0.9.2', 'console_scripts', 'conductor')()
  File "/usr/lib/python2.7/site-packages/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/container/cli.py", line 399, in conductor_commandline
    **params)
  File "/usr/lib/python2.7/site-packages/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/container/core.py", line 820, in conductorcmd_build
    image_id = engine.flatten_container(container_id, service_name, service)
  File "/usr/lib/python2.7/site-packages/container/docker/engine.py", line 105, in __wrapped__
    return fn(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/container/docker/engine.py", line 637, in flatten_container
    raw_image.read(),
AttributeError: 'generator' object has no attribute 'read'
```