### PR TITLE
Handle private registries which don't require auth

### DIFF
--- a/container/docker/engine.py
+++ b/container/docker/engine.py
@@ -1200,11 +1200,7 @@ class Engine(BaseEngine, DockerSecretsMixin):
 
             self._update_config_file(username, password, email, url, config_path)
 
-        username, password = self._get_registry_auth(url, config_path)
-        if not username:
-            raise exceptions.AnsibleContainerConductorException(
-                u'Please provide login credentials for registry {}.'.format(url))
-        return username, password
+        return self._get_registry_auth(url, config_path)
 
     @staticmethod
     @conductor_only


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Allow to push to private registries: remove exception.

Error was:

    $ ansible-container push --push-to myregistry
    Parsing conductor CLI args.
    Engine integration loaded. Preparing push.	engine=Docker™ daemon
    Traceback (most recent call last):
      File "/usr/local/bin/conductor", line 11, in <module>
        load_entry_point('ansible-container', 'console_scripts', 'conductor')()
      File "/_ansible/container/__init__.py", line 19, in __wrapped__
        return fn(*args, **kwargs)
      File "/_ansible/container/cli.py", line 399, in conductor_commandline
        **params)
      File "/_ansible/container/__init__.py", line 19, in __wrapped__
        return fn(*args, **kwargs)
      File "/_ansible/container/core.py", line 959, in conductorcmd_push
        username, password = engine.login(username, password, email, url, config_path)
      File "/_ansible/container/__init__.py", line 19, in __wrapped__
        return fn(*args, **kwargs)
      File "/_ansible/container/docker/engine.py", line 1134, in login
        u'Please provide login credentials for registry {}.'.format(url))
    container.exceptions.AnsibleContainerConductorException: Please provide login credentials for registry myregistry.test.
    Conductor terminated. Cleaning up.	command_rc=1 conductor_id=6bf66bde1725100e0baf80112dba1112999012dc9c5d94788e363f6ec89d5313 save_container=False
    ERROR	Conductor exited with status 1

Fixes #911