### PR TITLE
Handle filenames with unicode characters

### DIFF
--- a/container/utils/__init__.py
+++ b/container/utils/__init__.py
@@ -272,7 +272,7 @@ def get_role_fingerprint(role, service_name, config_vars):
         for root, dirs, files in os.walk(dir_path, topdown=True):
             for file_path in files:
                 abs_file_path = os.path.join(root, file_path)
-                hash_obj.update(abs_file_path)
+                hash_obj.update(abs_file_path.encode('utf-8'))
                 hash_obj.update('::')
                 hash_file(hash_obj, abs_file_path)
 


### PR DESCRIPTION
exception was:
```
Traceback (most recent call last):
  File "/usr/bin/conductor", line 11, in <module>
    load_entry_point('ansible-container', 'console_scripts', 'conductor')()
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/cli.py", line 423, in conductor_commandline
    **params)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/core.py", line 809, in conductorcmd_build
    role_fingerprint = get_role_fingerprint(role, service_name, config_vars)
  File "/_ansible/container/__init__.py", line 19, in __wrapped__
    return fn(*args, **kwargs)
  File "/_ansible/container/utils/__init__.py", line 322, in get_role_fingerprint
    hash_role(hash_obj, resolve_role_to_path(role))
  File "/_ansible/container/utils/__init__.py", line 308, in hash_role
    hash_dir(hash_obj, src)
  File "/_ansible/container/utils/__init__.py", line 275, in hash_dir
    hash_obj.update(abs_file_path)
UnicodeEncodeError: 'ascii' codec can't encode character u'\x93' in position 56: ordinal not in range(128)
```

##### ISSUE TYPE
 - Bugfix Pull Request

