### PR TITLE
Allow to run setup with pip < 9.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,11 @@ import distutils.log
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 from setuptools.command.sdist import sdist as SDistCommand
-from pip.req import parse_requirements
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
+
 import container
 
 class PlaybookAsTests(TestCommand):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
I'm so python developer, so feel free to closed and never merge this. I've just run into this issue, trying to play with Ansible Container on my Fedora 27, so I though I should share the fix.