### PR TITLE
Fix import of parse_requirements in setup.py for pip>=10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,12 @@ import distutils.log
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 from setuptools.command.sdist import sdist as SDistCommand
-from pip.req import parse_requirements
+
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 import container
 
 class PlaybookAsTests(TestCommand):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
Pip 10 was released a few weeks ago and moved parse_requirements from pip.req to
pip._internal.req. Thus, setup of ansible-container with pip 10 fails with this error:

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-q5c29n85/ansible-container/setup.py", line 10, in <module>
        from pip.req import parse_requirements
    ImportError: No module named 'pip.req'
```

I applied the fix described here https://stackoverflow.com/a/49867265/7662112

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
