### PR TITLE
Fixed import exception when using pip 10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ import distutils.log
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 from setuptools.command.sdist import sdist as SDistCommand
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 import container
 
 class PlaybookAsTests(TestCommand):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
When attempting to install ansible-container using pip 10+ you get an exception. 

```
Collecting ansible-container
  Using cached https://files.pythonhosted.org/packages/bc/2a/b1252de3931173d26a30fc965be33c9cc0044cf7b23ce4c707f55d86830c/ansible-container-0.9.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/ll/f9vvzm_j29zczm6j89vqclyw0000gn/T/pip-install-qTUFXW/ansible-container/setup.py", line 10, in <module>
        from pip.req import parse_requirements
    ImportError: No module named req
```
Added a check around the import to handle that parse_requirements are now in pip._internal.req, instead of pip.req.

This fixes the issue with the following pull request : https://github.com/pypa/pip/pull/4700, which is not in pip 10+
