### PR TITLE
Updates setup.py to work with pip9 and pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,14 @@ import distutils.log
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 from setuptools.command.sdist import sdist as SDistCommand
-from pip.req import parse_requirements
 import container
+
+try:
+    # pip10
+    from pip._internal.req import parse_requirements
+except ImportError:
+    # pip9
+    from pip.req import parse_requirements
 
 class PlaybookAsTests(TestCommand):
     user_options = [('ansible-args=', None, "Extra ansible arguments")]


### PR DESCRIPTION
Fixes #940 

[pip10 intentionally broke compatibility](https://github.com/pypa/pip/issues/5154#issuecomment-378197307) to prevent using internals.
However, there is no particular package that actually provides a way to
read requirements and convert them into a setup.py file, so package
developers are stuck with using pip.*.req.
