### PR TITLE
fix(tests) https validation in older python

### DIFF
--- a/container/docker/templates/conductor-local-dockerfile.j2
+++ b/container/docker/templates/conductor-local-dockerfile.j2
@@ -1,5 +1,8 @@
 FROM {{ conductor_base }}
 {% set distro = original_base.split(':')[0] %}
+{% if distro_version in ["wheezy", "precise", "trusty"] %}
+  pip install -U pyopenssl ndg-httpsclient pyasn1 && \
+{% endif %}
 # The COPY here will break cache if the requirements or ansible.cfg has changed
 COPY /build-src /_ansible/build
 

--- a/container/docker/templates/conductor-src-dockerfile.j2
+++ b/container/docker/templates/conductor-src-dockerfile.j2
@@ -48,6 +48,9 @@ RUN apk add --no-cache -U python-dev make git curl rsync libffi libffi-dev opens
 RUN (curl https://bootstrap.pypa.io/get-pip.py | python - --no-cache-dir ) && \
     mkdir -p /etc/ansible/roles /_ansible/src && \
     mkdir -p /licenses && \
+    {% if distro_version in ["wheezy", "precise", "trusty"] %}
+    pip install -U pyopenssl ndg-httpsclient pyasn1 && \
+    {% endif %}
     (curl https://get.docker.com/builds/Linux/x86_64/docker-{{ docker_version }}.tgz \
        | tar -zxC /usr/local/bin/ --strip-components=1 docker/docker )
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
Fixes https issues with pip during conductor image baking in wheezy, precise, trusty
