### PR TITLE
Lock ruamel.yaml version to [0.15.34; 0.15.51]. Fixes #958

### DIFF
--- a/conductor-requirements.txt
+++ b/conductor-requirements.txt
@@ -3,7 +3,7 @@ https://github.com/openshift/openshift-restclient-python/archive/master.tar.gz#e
 PyYAML>=3.12
 docker-compose>=1.14
 requests>=2,<2.16
-ruamel.yaml>=0.15.34
+ruamel.yaml>=0.15.34,<=0.15.51
 six>=1.10
 structlog[dev]>=16.1
 python-string-utils>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pip>=6.0
 PyYAML>=3.12
 docker==2.7.0
 requests>=2
-ruamel.yaml>=0.15.34
+ruamel.yaml>=0.15.34,<=0.15.51
 six>=1.10
 structlog[dev]>=16.1
 jsonschema==2.6.0


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Versions of ruamel.yaml >=0.15.52 cause ansible-container build to fail with `'CommentedMap' is not JSON serializable` error. See issue #958

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

To reproduce the issue:
```
$ virtualenv venv
$ source venv/bin/activate
$ git clone https://github.com/ansible/ansible-container.git
$ pip install -e ansible-container
$ ansible-container init
$ ansible-container build
```

Before the change:
```
$ ansible-container build
ERROR	The container.yml file is invalid: ordereddict([('version', '2'), ('settings', ordereddict([('conductor', ordereddict([('base', 'centos:7')])), ('project_name', 'tmp.sKmOGhyCo7')])), ('services', ordereddict()), ('registries', ordereddict())]) is not of type 'object'	
Building Docker Engine context...	
Starting Docker build of Ansible Container Conductor image (please be patient)...	
ERROR	Unknown exception	
Traceback (most recent call last):
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/cli.py", line 302, in __call__
    getattr(core, u'hostcmd_{}'.format(args.subcommand))(**vars(args))
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/core.py", line 204, in hostcmd_build
    'build', dict(config), base_path, kwargs, save_container=save_container)
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/docker/engine.py", line 468, in await_conductor_command
    conductor_id = self.run_conductor(command, config, base_path, params)
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/docker/engine.py", line 107, in __wrapped__
    return fn(self, *args, **kwargs)
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/__init__.py", line 28, in __wrapped__
    return fn(*args, **kwargs)
  File "/tmp/tmp.sKmOGhyCo7/ansible-container/container/docker/engine.py", line 422, in run_conductor
    serialized_config = base64.b64encode(json.dumps(ordereddict_to_list(config)).encode("utf-8")).decode()
  File "/usr/lib64/python3.6/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib64/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'CommentedMap' is not JSON serializable
```

After the change: (i.e. change `git clone` to tzok/ansible-container)
```
$ ansible-container build
Building Docker Engine context...	
Starting Docker build of Ansible Container Conductor image (please be patient)...	
Parsing conductor CLI args.
Copying build context into Conductor container.
Docker™ daemon integration engine loaded. Build starting.	project=tmp.HWGEm38Ly1
All images successfully built.
Conductor terminated. Cleaning up.	command_rc=0 conductor_id=4f6a7596886ba7adb75c8f8ea4dc67de4b7204e534c161c70fa9607550321eea save_container=False
```