### PR TITLE
Fix return code on refused Docker connection

### DIFF
--- a/container/cli.py
+++ b/container/cli.py
@@ -323,6 +323,7 @@ class HostCommand(object):
         except exceptions.AnsibleContainerDockerConnectionRefused:
             logger.error('The connection to Docker was refused. Check your Docker environment configuration.',
                          exc_info=False)
+            sys.exit(1)
         except exceptions.AnsibleContainerDockerConnectionAborted as e:
             logger.error('The connection to Docker was aborted. Check your Docker environment configuration.\n'
                          'ErrorMessage: %s' % str(e),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY
If the connection to Docker is refused ansible-container prints an error but exits with 0 (= success). This leads to e.g. CI build jobs passing although they actually did not pass. This patch lets ansible-container fail with exit code 1 if the connection to Docker is refused.

Before this change:
```
$ sudo service docker stop
$ ansible-container build
ERROR	The connection to Docker was refused. Check your Docker environment configuration.
$ echo $?
0
```

After this change:
```
$ sudo service docker stop
$ ansible-container build
ERROR	The connection to Docker was refused. Check your Docker environment configuration.
$ echo $?
1
```