### PR TITLE
improve(bakery) support for custom organization providing prebaked conductor images

### DIFF
--- a/bakery.py
+++ b/bakery.py
@@ -15,12 +15,15 @@ import container
 
 version = container.__version__
 
-BASE_DISTRO = os.getenv('BASE_DISTRO');
+BASE_DISTRO = os.getenv('BASE_DISTRO')
+CONDUCTOR_PROVIDER = os.getenv('CONDUCTOR_PROVIDER') or 'ansible'
 
 if BASE_DISTRO:
-    subprocess.check_call(['python', 'setup.py', 'prebake', '--distros', BASE_DISTRO])
+    print "building selected prebake distros %s for organization %s" % (BASE_DISTRO, CONDUCTOR_PROVIDER)
+    subprocess.check_call(['python', 'setup.py', 'prebake', '--distros', BASE_DISTRO, '--conductor-provider', CONDUCTOR_PROVIDER])
 else:
-    subprocess.check_call(['python', 'setup.py', 'prebake'])
+    print "building prebake distros for organization %s" % (CONDUCTOR_PROVIDER)
+    subprocess.check_call(['python', 'setup.py', 'prebake', '--conductor-provider', CONDUCTOR_PROVIDER])
 
 for distro in ([BASE_DISTRO] if BASE_DISTRO else PREBAKED_DISTROS):
     print('Uploading %s...' % distro)
@@ -30,9 +33,9 @@ for distro in ([BASE_DISTRO] if BASE_DISTRO else PREBAKED_DISTROS):
            'ansible/container-conductor-%s:%s' % (distro_key, version)])
     subprocess.check_call(['docker', 'tag',
                            'container-conductor-%s:%s' % (distro_key, version),
-                           'ansible/container-conductor-%s:%s' % (distro_key, version)])
+                           '%s/container-conductor-%s:%s' % (CONDUCTOR_PROVIDER, distro_key, version)])
     print(['docker', 'push',
-           'ansible/container-conductor-%s:%s' % (distro_key, version)])
+           '%s/container-conductor-%s:%s' % (CONDUCTOR_PROVIDER, distro_key, version)])
     subprocess.check_call(['docker', 'push',
-                           'ansible/container-conductor-%s:%s' % (distro_key, version)])
+                           '%s/container-conductor-%s:%s' % (CONDUCTOR_PROVIDER, distro_key, version)])
 

--- a/container/__init__.py
+++ b/container/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-__version__ = '0.9.3rc0'
+__version__ = '0.9.3rc2'
 
 import os
 import functools

--- a/container/templates/init/.dockerignore.j2
+++ b/container/templates/init/.dockerignore.j2
@@ -5,3 +5,7 @@
 ansible-deployment/
 *.retry
 .DS_Store
+p-env
+venv
+.p-env
+.venv


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

Addresses proposal  in  https://github.com/ansible/ansible-container/issues/965

##### SUMMARY

Allows 3rd parties to prebake and push custom conductor images with bakery command

```
CONDUCTOR_PROVIDER=softasap  python bakery.py
```

Allows also setting optional `conductor_provider: ORG` to provide a hint from which organization (default ansible) prebaked conductor image should be pulled from

```
version: "2"
settings:
  conductor_base: alpine:3.5
  conductor_provider: softasap
  volumes:
   - temp-space:/tmp   # Used to copy static content between containers

services:

   api-alpine:
     from: python:3.6.3-alpine3.6
     container_name: api-alpine
     entrypoint: [/docker-entrypoint]
     roles:
       - {
           role: "softasap.sa-container-bootstrap",
           option_container_syslog_ng: false,
           option_container_sshd: false
         }
#       - {
#           role: "softasap.sa-nginx-container",
#           container_init: "phusion-init" # uses runit for services management and upstart.
#         }
#       - {
#           role: "../custom-roles/app-nginx-stub-deploy"
#         }
     expose:
       - '8000'
     volumes:
        - temp-space:/tmp   # Used to copy static content between containers
     environment:
        IN_DOCKER: "1"

volumes:
  temp-space:
    docker: {}
```